### PR TITLE
updated pose message with timestamp and mapper housekeeping with Vali…

### DIFF
--- a/fsw/public_inc/mapper_msgs.h
+++ b/fsw/public_inc/mapper_msgs.h
@@ -40,6 +40,7 @@ typedef struct
 	uint8			CommandCounter;
 	uint8			CommandErrorCounter;
 	uint8			PoseCounter;
+	uint8			ValidPoseCounter;
 	uint8			GoalCounter;
 	uint8			PclCounter;
 	uint8			MeshCounter;

--- a/fsw/public_inc/pose_msg.h
+++ b/fsw/public_inc/pose_msg.h
@@ -26,7 +26,7 @@
 typedef double float64;
 
 typedef struct {
-  uint64  timestamp; // microseconds
+  CFE_TIME_SysTime_t  timestamp; // microseconds
   float64 x_pos;     // meters
   float64 y_pos;     // meters
   float64 z_pos;     // meters

--- a/fsw/public_inc/pose_msg.h
+++ b/fsw/public_inc/pose_msg.h
@@ -26,6 +26,7 @@
 typedef double float64;
 
 typedef struct {
+  int64   timestamp; //nanoseconds
   float64 x_pos;  // meters
   float64 y_pos;  // meters
   float64 z_pos;  // meters

--- a/fsw/public_inc/pose_msg.h
+++ b/fsw/public_inc/pose_msg.h
@@ -26,14 +26,14 @@
 typedef double float64;
 
 typedef struct {
-  int64   timestamp; //nanoseconds
-  float64 x_pos;  // meters
-  float64 y_pos;  // meters
-  float64 z_pos;  // meters
-  float64 x_quat; // quaternion
-  float64 y_quat; // quaternion
-  float64 z_quat; // quaternion
-  float64 w_quat; // quaternion
+  uint64  timestamp; // microseconds
+  float64 x_pos;     // meters
+  float64 y_pos;     // meters
+  float64 z_pos;     // meters
+  float64 x_quat;    // quaternion
+  float64 y_quat;    // quaternion
+  float64 z_quat;    // quaternion
+  float64 w_quat;    // quaternion
   float64 covariance[36];
 } MOONRANGER_Pose_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request addresses updating Pose message structure and the HK message structure. It involves adding two new fields to the aforementioned structures.
## 
<!--- Why is this change required? What problem does it solve? -->
This changes has been required to be in adherence with the Mapper App design documentation  and Mappers ability to verify Pose messages and filter out bad pose messages.