### PR TITLE
sb_transport_lib Software Bus msg struct 

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -56,6 +56,9 @@
 #define CAMERA_IF_SEND_HK_MID 0x1887
 #define CAMERA_IF_HK_TLM_MID 0x0887
 
+/* Unused, but need to be reserved */
+#define SB_TRANSPORT_LIB_CMD_MID 0x12FF
+
 /**
  * State Estimator Message IDs
  * @note  Message IDS in this section should fit within

--- a/fsw/public_inc/sb_transport_msg.h
+++ b/fsw/public_inc/sb_transport_msg.h
@@ -24,15 +24,15 @@
 /**
  * @brief Generic Msg type for Software Bus Transport Library.
  *
- * WARNING: do not use this msg directly, it is recommended to use
- * the API of sb_transport_lib to read/write the data as it provides
- * mutex locks to prevent data race conditions.
+ * Send this msg to inform other apps that you have written new data to the
+ * shared memory buffer.
+ * WARNING: use the API of sb_transport_lib for read/write.
  */
 typedef struct {
     CFE_SB_Msg_t MsgHdr;   // cFE generic msg header.
-    void* DataHandle;      // Pointer to the data.
-    size_t DataSize;       // Size of the data in bytes.
-    bool IsValid;          // Flag to check if msg is valid.
 } SB_Transport_Msg_t;
+
+typedef SB_Transport_Msg_t SB_Stereo_Img_Transport_Msg_t;
+typedef SB_Transport_Msg_t SB_Pcl_Transport_Msg_t;
 
 #endif   //_moonranger_sb_transport_lib_msg_h_


### PR DESCRIPTION
add msg type for informing other apps that you have written new data with the sb_transport_lib API

## 
The previous iteration of sb_transport_lib sends raw pointer through SB msgs, now we are only sending notification.

## How has this been tested?
unit tests as part of sb_transport_lib. No unit tests here in the msg definition files

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
