### PR TITLE
Add messages file for the common table manager app

### DIFF
--- a/fsw/public_inc/tbl_manager_msgs.h
+++ b/fsw/public_inc/tbl_manager_msgs.h
@@ -1,0 +1,67 @@
+/****************************************************************
+ *
+ * @file 		tbl_manager_msg.h
+ *
+ * @brief 		Housekeeping/telem message type definition for table
+ * manager.
+ *
+ * @version 		1.0
+ * @date 		10/20/2021
+ *
+ * @authors 	Amy Lin, Margaret Hansen
+ * @author 		Carnegie Mellon University, Planetary Robotics Lab
+ *
+ ****************************************************************/
+
+#ifndef _tbl_manager_msg_h_
+#define _tbl_manager_msg_h_
+
+/**
+ * Table manager command codes
+ */
+
+#define TBL_MANAGER_NOOP_CC 0
+#define TBL_MANAGER_RESET_COUNTERS_CC 1
+#define TBL_MANAGER_RECEIVE_UPDATE_CC 2
+
+/**
+ * Table manager Message IDs
+ */
+
+#define TBL_MANAGER_CMD_MID 0x18E6
+#define TBL_MANAGER_SEND_HK_MID 0x18E7
+#define TBL_MANAGER_SEND_UPDATE_MID 0x18E8
+#define TBL_MANAGER_HK_TLM_MID 0x08E7
+
+/**
+ * Command data structure
+ */
+
+typedef struct
+{
+  uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+} TBL_MANAGER_NoArgsCmd_t;
+
+typedef TBL_MANAGER_NoArgsCmd_t TBL_MANAGER_Noop_t;
+typedef TBL_MANAGER_NoArgsCmd_t TBL_MANAGER_ResetCounters_t;
+typedef TBL_MANAGER_NoArgsCmd_t TBL_MANAGER_Update_t;
+
+
+/***************************************************
+/*
+** Type definition (TBL_MANAGER housekeeping/telemetry)
+*/
+
+typedef struct {
+    uint8 TblUpdateCounter;
+    uint8 spare[2];
+} TBL_MANAGER_HkTlm_Payload_t;
+
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    TBL_MANAGER_HkTlm_Payload_t Payload;
+} OS_PACK TBL_MANAGER_HkTlm_t;
+
+#endif /* _tbl_manager_msg_h_ */
+
+/* EOF */


### PR DESCRIPTION
## Description
Adds the messages file for the tbl_manager app in [pull request 184](https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/184)

## 
Adds the messages for the tbl_manager app ([pull request 184](https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/184)) to close [issue 118](https://github.com/PlanetaryRobotics/moonranger-rover-flight/issues/118).

## How has this been tested?
Run in docker container alongside scratch/tbl_manager branch of the flight repo. Builds, ./core-tx2i runs, and all tests pass

## Screenshots (if appropriate):

![Kazam_screenshot_00121](https://user-images.githubusercontent.com/46793318/142069316-2af8e1a2-7878-4c84-aefa-030cc7351f2f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
