### PR TITLE
Add stereo_reconstructor messages

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -74,9 +74,9 @@
  * @note Telemetry message IDs in this section should fit within
  * 0x09C0-0x09FF inclusive.
  */
-#define STEREO_CMD_MID 0x18A0
-#define STEREO_SEND_HK_MID 0x18A1
-#define STEREO_HK_TLM_MID 0x18A2
+#define STEREO_CMD_MID 0x19C0
+#define STEREO_SEND_HK_MID 0x19C1
+#define STEREO_HK_TLM_MID 0x09C2
 
 /**
  * Planner Message IDs

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -77,6 +77,9 @@
  * @note  Message IDS in this section should fit within
  * 0x0400-0x04FF inclusive.
  */
+#define STEREO_CMD_MID 0x18A0
+#define STEREO_SEND_HK_MID 0x18A1
+#define STEREO_HK_TLM_MID 0x18A2
 
 /**
  * Mapper Message IDs
@@ -157,12 +160,10 @@
 
 #define SCH_HK_TLM_MID                 0x0897 /**< \brief SCH Housekeeping Telemetry Message ID */
 #define SCH_DIAG_TLM_MID               0x0898 /**< \brief SCH Diagnostic Telemetry Message ID */
-/* 
+/*
 #define SCH_TLM_SPARE1                 0x0899
 #define SCH_TLM_SPARE2                 0x089A
 */
-
-
 
 /**
  * MOONRANGER Common Message IDs

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -1,22 +1,42 @@
-/**************************************************************** * * @file
- * stereo_reconstructor_msgs.h * * @brief stereo reconstructor msgs * *
- * @version 1.0 * @date 11/13 * * @authors Amy Lin * @author Carnegie Mellon
- * University, Planetary Robotics Lab * * * @note This file only contains app
+/**************************************************************** * * 
+ * @file stereo_reconstructor_msgs.h
+ * @brief stereo reconstructor msgs
+ * @version 1.0 * 
+ * @date 11/13 * * 
+ * @authors Amy Lin * 
+ * @author Carnegie Mellon University, Planetary Robotics Lab * * * 
+ * @note This file only contains app
  * specific command and * telemetry message definitions and command codes.
  * ****************************************************************/
-#ifndef _stereo_reconstructor_msgs_h #define _stereo_reconstructor_msgs_h
+#ifndef _stereo_reconstructor_msgs_h 
+#define _stereo_reconstructor_msgs_h
+
+/*************************************************************************/
 /*** STEREO App command codes*/
-#define STEREO_NOOP_CC 0 #define STEREO_RESET_COUNTERS_CC 1
-    /*************************************************************************/
-    /*** Type definition (generic "no arguments" command)*/ typedef struct {
+#define STEREO_NOOP_CC 0 
+#define STEREO_RESET_COUNTERS_CC 1
+
+/*************************************************************************/
+/*** Msg IDs*/
+
+#define STEREO_CMD_MID 0x1882
+#define STEREO_SEND_HK_MID 0x1883
+#define STEREO_HK_TLM_MID 0x0883
+
+/*************************************************************************/
+/*** Type definition (generic "no arguments" command)*/ 
+
+typedef struct {
     uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 } STEREO_NoArgsCmd_t;
+
 /*** The following commands all share the "NoArgs" format**** They are each
  * given their own type name matching the command name, which_open_mode** allows
  * them to change independently in the future without changing the prototype**
  * of the handler function*/
 typedef STEREO_NoArgsCmd_t STEREO_Noop_t;
 typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
+typedef STEREO_NoArgsCmd_t STEREO_Process_t;
 /*************************************************************************/ /***
                                                                                Type definition (STEREO App housekeeping)*/
 typedef struct {

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -17,11 +17,6 @@
 #define STEREO_RESET_COUNTERS_CC 1
 
 /*************************************************************************/
-/*** Msg IDs*/
-
-// see moonranger_msgids.h
-
-/*************************************************************************/
 /*** Type definition (generic "no arguments" command)*/
 
 typedef struct {

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -35,8 +35,13 @@ typedef struct {
 typedef STEREO_NoArgsCmd_t STEREO_Noop_t;
 typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
 typedef STEREO_NoArgsCmd_t STEREO_Process_t;
-/*************************************************************************/ /***
-                                                                               Type definition (STEREO App housekeeping)*/
+
+/*************************************************************************/ 
+/** Type definition (STEREO App housekeeping)*/
+
+#define STEREO_HK_PAYLOAD_LEN               sizeof(STEREO_HkTlm_Payload_t)
+#define STEREO_HK_TLM_LEN                   sizeof(STEREO_HkTlm_t)
+
 typedef struct {
     uint8 CommandErrorCounter;
     uint8 CommandCounter;

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -1,30 +1,30 @@
-/**************************************************************** * * 
+/**************************************************************** * *
  * @file stereo_reconstructor_msgs.h
  * @brief stereo reconstructor msgs
- * @version 1.0 * 
- * @date 11/13 * * 
- * @authors Amy Lin * 
- * @author Carnegie Mellon University, Planetary Robotics Lab * * * 
+ * @version 1.0 *
+ * @date 11/13 * *
+ * @authors Amy Lin *
+ * @author Carnegie Mellon University, Planetary Robotics Lab * * *
  * @note This file only contains app
  * specific command and * telemetry message definitions and command codes.
  * ****************************************************************/
-#ifndef _stereo_reconstructor_msgs_h 
+#ifndef _stereo_reconstructor_msgs_h
 #define _stereo_reconstructor_msgs_h
 
 /*************************************************************************/
 /*** STEREO App command codes*/
-#define STEREO_NOOP_CC 0 
+#define STEREO_NOOP_CC 0
 #define STEREO_RESET_COUNTERS_CC 1
 
 /*************************************************************************/
 /*** Msg IDs*/
 
-#define STEREO_CMD_MID 0x1882
-#define STEREO_SEND_HK_MID 0x1883
-#define STEREO_HK_TLM_MID 0x0883
+#define STEREO_CMD_MID 0x18A0
+#define STEREO_SEND_HK_MID 0x18A1
+#define STEREO_HK_TLM_MID 0x18A2
 
 /*************************************************************************/
-/*** Type definition (generic "no arguments" command)*/ 
+/*** Type definition (generic "no arguments" command)*/
 
 typedef struct {
     uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -1,38 +1,12 @@
-/****************************************************************
- * 
- * @file      TODO
- * 
- * @brief     TODO
- * 
- * @version   TODO
- * @date   		TODO
- * 
- * @authors 	TODO
- * @author 		Carnegie Mellon University, Planetary Robotics Lab
- * 
- * 
- * @note		This file only contains app specific command and 
- * 				telemetry message definitions and command codes.
- ****************************************************************/
-
-
-/*********************************************************************
- * INSTRUCTIONS
- * 
- * This file should contain all the type definitions for app specific messages such as
- * housekeeping / telemetry.
- * 
- * It should also contain definitions for all command messages and command codes.
- * 
- * All message IDs should be placed in moonranger_messageids.h in the appropriately marked location
- * 
- * DELETE THIS BLOCK ONCE COMPLETE
- *******************************************************************/
-
-#ifndef _stereo_reconstructor_msgs_h
-#define _stereo_reconstructor_msgs_h
-
-
-
-
-#endif /* _stereo_reconstructor_h */
+/**************************************************************** * * @file stereo_reconstructor_msgs.h * * @brief stereo reconstructor msgs * * @version 1.0 * @date 11/13 * * @authors Amy Lin * @author Carnegie Mellon University, Planetary Robotics Lab * * * @note This file only contains app specific command and * telemetry message definitions and command codes. ****************************************************************/
+#ifndef _stereo_reconstructor_msgs_h#define _stereo_reconstructor_msgs_h
+/*** STEREO App command codes*/#define STEREO_NOOP_CC 0#define STEREO_RESET_COUNTERS_CC 1
+/*************************************************************************/
+/*** Type definition (generic "no arguments" command)*/typedef struct{ uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+} STEREO_NoArgsCmd_t;
+/*** The following commands all share the "NoArgs" format**** They are each given their own type name matching the command name, which_open_mode** allows them to change independently in the future without changing the prototype** of the handler function*/typedef STEREO_NoArgsCmd_t STEREO_Noop_t;typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
+/*************************************************************************//*** Type definition (STEREO App housekeeping)*/
+typedef struct{ uint8 CommandErrorCounter; uint8 CommandCounter; uint8 spare[2];} STEREO_HkTlm_Payload_t;
+typedef struct{ uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE]; STEREO_HkTlm_Payload_t Payload;
+} OS_PACK STEREO_HkTlm_t;
+#endif /* _stereo_reconstructor_msg_h_ */

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -19,9 +19,7 @@
 /*************************************************************************/
 /*** Msg IDs*/
 
-#define STEREO_CMD_MID 0x18A0
-#define STEREO_SEND_HK_MID 0x18A1
-#define STEREO_HK_TLM_MID 0x18A2
+// see moonranger_msgids.h
 
 /*************************************************************************/
 /*** Type definition (generic "no arguments" command)*/

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -1,12 +1,31 @@
-/**************************************************************** * * @file stereo_reconstructor_msgs.h * * @brief stereo reconstructor msgs * * @version 1.0 * @date 11/13 * * @authors Amy Lin * @author Carnegie Mellon University, Planetary Robotics Lab * * * @note This file only contains app specific command and * telemetry message definitions and command codes. ****************************************************************/
-#ifndef _stereo_reconstructor_msgs_h#define _stereo_reconstructor_msgs_h
-/*** STEREO App command codes*/#define STEREO_NOOP_CC 0#define STEREO_RESET_COUNTERS_CC 1
-/*************************************************************************/
-/*** Type definition (generic "no arguments" command)*/typedef struct{ uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+/**************************************************************** * * @file
+ * stereo_reconstructor_msgs.h * * @brief stereo reconstructor msgs * *
+ * @version 1.0 * @date 11/13 * * @authors Amy Lin * @author Carnegie Mellon
+ * University, Planetary Robotics Lab * * * @note This file only contains app
+ * specific command and * telemetry message definitions and command codes.
+ * ****************************************************************/
+#ifndef _stereo_reconstructor_msgs_h #define _stereo_reconstructor_msgs_h
+/*** STEREO App command codes*/
+#define STEREO_NOOP_CC 0 #define STEREO_RESET_COUNTERS_CC 1
+    /*************************************************************************/
+    /*** Type definition (generic "no arguments" command)*/ typedef struct {
+    uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 } STEREO_NoArgsCmd_t;
-/*** The following commands all share the "NoArgs" format**** They are each given their own type name matching the command name, which_open_mode** allows them to change independently in the future without changing the prototype** of the handler function*/typedef STEREO_NoArgsCmd_t STEREO_Noop_t;typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
-/*************************************************************************//*** Type definition (STEREO App housekeeping)*/
-typedef struct{ uint8 CommandErrorCounter; uint8 CommandCounter; uint8 spare[2];} STEREO_HkTlm_Payload_t;
-typedef struct{ uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE]; STEREO_HkTlm_Payload_t Payload;
+/*** The following commands all share the "NoArgs" format**** They are each
+ * given their own type name matching the command name, which_open_mode** allows
+ * them to change independently in the future without changing the prototype**
+ * of the handler function*/
+typedef STEREO_NoArgsCmd_t STEREO_Noop_t;
+typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
+/*************************************************************************/ /***
+                                                                               Type definition (STEREO App housekeeping)*/
+typedef struct {
+    uint8 CommandErrorCounter;
+    uint8 CommandCounter;
+    uint8 spare[2];
+} STEREO_HkTlm_Payload_t;
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    STEREO_HkTlm_Payload_t Payload;
 } OS_PACK STEREO_HkTlm_t;
 #endif /* _stereo_reconstructor_msg_h_ */


### PR DESCRIPTION
Updates the placeholder stereo_reconstructor_msgs.h to include the skeleton messages for the stereo_reconstructor app 

## Description
Just basic skeleton app messages; nothing unique to stereo_reconstructor yet

## 
Related issue (Perception - Skeleton App): https://github.com/PlanetaryRobotics/moonranger-rover-flight/issues/48

## How has this been tested?
Compiled alongside scratch/stereo_reconstructor branch of the main repo. Builds and all unit tests pass.

## Screenshots (if appropriate):

```Running tests...
Test project /home/moonranger/moonranger-rover-flight/build
      Start  1: CS
 1/15 Test  #1: CS ...............................   Passed    2.40 sec
      Start  2: LC
 2/15 Test  #2: LC ...............................   Passed    2.22 sec
      Start  3: SC
 3/15 Test  #3: SC ...............................   Passed    2.32 sec
      Start  4: camera_if
 4/15 Test  #4: camera_if ........................   Passed    2.37 sec
      Start  5: cmd_ingest
 5/15 Test  #5: cmd_ingest .......................   Passed    2.29 sec
      Start  6: hs
 6/15 Test  #6: hs ...............................   Passed    2.39 sec
      Start  7: mapper
 7/15 Test  #7: mapper ...........................   Passed    2.32 sec
      Start  8: moonranger_msgs
 8/15 Test  #8: moonranger_msgs ..................   Passed    2.25 sec
      Start  9: planner
 9/15 Test  #9: planner ..........................   Passed    2.27 sec
      Start 10: pose_estimator
10/15 Test #10: pose_estimator ...................   Passed    2.20 sec
      Start 11: sb_transport_lib
11/15 Test #11: sb_transport_lib .................   Passed    2.22 sec
      Start 12: sch
12/15 Test #12: sch ..............................   Passed    2.22 sec
      Start 13: stereo_reconstructor
13/15 Test #13: stereo_reconstructor .............   Passed    2.28 sec
      Start 14: tlm_output
14/15 Test #14: tlm_output .......................   Passed    2.24 sec
      Start 15: vehicle_controller
15/15 Test #15: vehicle_controller ...............   Passed    2.32 sec

100% tests passed, 0 tests failed out of 15

Total Test time (real) =  34.34 sec
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
