### PR TITLE
[msgids] fix bug whereby cmd ids must be >0x1800

### DIFF
--- a/fsw/public_inc/camera_if_msgs.h
+++ b/fsw/public_inc/camera_if_msgs.h
@@ -26,6 +26,7 @@
 #define CAMERA_IF_NOOP_CC                   0
 #define CAMERA_IF_RESET_COUNTERS_CC         1
 #define CAMERA_IF_SAVE_IMAGE_CC             2
+#define CAMERA_IF_SEND_STEREO_IMAGE_CC      3
 
 /*************************************************************************/
 /*
@@ -41,6 +42,7 @@ typedef struct
 typedef CAMERA_IF_NoArgsCmd_t CAMERA_IF_Noop_t;
 typedef CAMERA_IF_NoArgsCmd_t CAMERA_IF_ResetCounters_t;
 typedef CAMERA_IF_NoArgsCmd_t CAMERA_IF_SaveImage_t;
+typedef CAMERA_IF_NoArgsCmd_t CAMERA_IF_SendStereoImg_t;
 
 /*************************************************************************/
 /*
@@ -68,5 +70,10 @@ typedef struct
 {
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK CAMERA_IF_ImgSavedTlm_t;
+
+typedef struct
+{
+  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+} OS_PACK CAMERA_IF_SendStereoImgTlm_t;
 
 #endif /* _camera_if_msgs_h */

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -1,120 +1,181 @@
-/**
- * @file moonranger_msgids.h
+/****************************************************************
  *
- * @brief defines all MoonRanger Message IDs
+ * @file      moonranger_msgids.h
  *
+ * @brief     Defines all of MoonRanger's Message IDs.
  *
- * @authors
- * @author Carnegie Mellon University Planetary Robotics Lab
- * @note
- */
-
-
-//TODO - Update IDs to ensure the values are in specified ranges
-//NOTE - need to check if there are specific values for command and telem.
+ *            Default cFS's apps (such as scheduler and cmd_ingest) will have
+ *            0x18xx and 0x08xx addresses for commands and telemetry.
+ *
+ *            Custom Moonranger apps (such as camera_if and mapper) will use
+ *            0x1900 to 0x1FFF addresses for commands and 0x0900 to 0x0FFF
+ *            addresses for telemetry
+ *
+ * @version   1.0
+ * @date      11/24/2021
+ *
+ * @author    Carnegie Mellon University, Planetary Robotics Lab
+ *
+ ****************************************************************/
 
 #ifndef _moonranger_msgids_h_
 #define _moonranger_msgids_h_
 
 /**
- * GROUND Command Message IDs
- * @note Message IDS in this section should fit within
- * 0x0F00-0xFFF inclusive.
- */
-
-/**
  * IMU Driver Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0104-0x01FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x1900-0x193F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0900-0x093F inclusive.
  */
-#define IMU_DRIVER_SEND_HK_MID 0x0104
-#define IMU_DRIVER_CMD_MID     0x0105
-#define IMU_DRIVER_HK_TLM_MID  0x0106
-
+#define IMU_DRIVER_CMD_MID 0x1900
+#define IMU_DRIVER_SEND_HK_MID 0x1901
+#define IMU_DRIVER_HK_TLM_MID 0x0901
 
 /**
- * Camera Driver Message IDs
- * @note  Command messages IDs in this section must be selected from
- * usused numbers between 0x1200 and 0x127F inclusive
- *
- * @note Telemetry Message IDs in this section must be selected from
- * usused numbers between 0x0200 and 0x027F inclusive
- */
-
-/**
- * Camera Interface Message IDs
- * @note  Command messages IDs in this section must be selected from
- * usused numbers between 0x1280 and 0x12FF inclusive
- *
- * @note Telemetry Message IDs in this section must be selected from
- * usused numbers between 0x0280 and 0x02FF inclusive
+ * Camera Driver & Camera Interface Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1940-0x197F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0940-0x097F inclusive.
  */
 
 /* Command to save the next available image captured from camera to disk */
-#define CAMERA_IF_CMD_MID 0x1886
+#define CAMERA_IF_CMD_MID 0x1940
 /* Telemetry that indicates image has been saved to disk and that image needs to
  * be sent back to earth */
-#define CAMERA_IF_IMG_SAVED_TLM_MID 0x0886
+#define CAMERA_IF_IMG_SAVED_TLM_MID 0x0940
 
 /* Housekeeping */
-#define CAMERA_IF_SEND_HK_MID 0x1887
-#define CAMERA_IF_HK_TLM_MID 0x0887
+#define CAMERA_IF_SEND_HK_MID 0x1941
+#define CAMERA_IF_HK_TLM_MID 0x0941
 
-/* Unused, but need to be reserved */
-#define SB_TRANSPORT_LIB_CMD_MID 0x12FF
+/* Stereo Msg sent */
+#define CAMERA_IF_NEW_STEREO_IMG_TLM_MID 0x0942
+
+/* Unused, but needs to be reserved */
+#define SB_TRANSPORT_LIB_CMD_MID 0x197F
 
 /**
  * Pose Estimator Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0300-0x03FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x1980-0x19BF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0980-0x09BF inclusive.
  */
-#define POSE_SEND_HK_MID 0x0300
-#define POSE_CMD_MID     0x0301
-#define POSE_HK_TLM_MID  0x0302
+#define POSE_CMD_MID 0x1980
+#define POSE_SEND_HK_MID 0x1981
+#define POSE_HK_TLM_MID 0x0981
 
 /**
  * Stereo Reconstructor Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0400-0x04FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x19C0-0x19FF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x09C0-0x09FF inclusive.
  */
-
-/**
- * Mapper Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0500-0x05FF inclusive.
- */
-#define MAPPER_CMD_MID 0x1882
-#define MAPPER_SEND_HK_MID 0x1883
-#define MAPPER_HK_TLM_MID 0x0883
 
 /**
  * Planner Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0600-0x06FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x1A00-0x1A3F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0A00-0x0A3F inclusive.
  */
-#define PLANNER_CMD_MID 0x18E0
-#define PLANNER_SEND_HK_MID 0x18E1
-#define PLANNER_HK_TLM_MID 0x08E2
+#define PLANNER_CMD_MID 0x1A00
+#define PLANNER_SEND_HK_MID 0x1A01
+#define PLANNER_HK_TLM_MID 0x0A01
+
+/**
+ * Mapper Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1A40-0x1A7F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0A40-0x0A7F inclusive.
+ */
+#define MAPPER_CMD_MID 0x1A40
+#define MAPPER_SEND_HK_MID 0x1A41
+#define MAPPER_HK_TLM_MID 0x0A41
 
 /**
  * Vehicle Controller Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0700-0x07FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x1A80-0x1ABF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0A80-0x0ABF inclusive.
  */
-#define VEHICLE_SEND_HK_MID 0x0700
-#define VEHICLE_CMD_MID     0x0701
-#define VEHICLE_HK_TLM_MID  0x0702
+#define VEHICLE_CMD_MID 0x1A80
+#define VEHICLE_SEND_HK_MID 0x1A81
+#define VEHICLE_HK_TLM_MID 0x0A81
 
 /**
  * Peripheral Data Manager Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0800-0x08FF inclusive.
+ * @note Command message IDs in this section should fit within
+ * 0x1AC0-0x1AFF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0AC0-0x0AFF inclusive.
  */
 
 /**
- * Telemetry Output Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0900-0x09FF inclusive.
+ * GROUND Command Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1B00-0x1B3F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0B00-0x0B3F inclusive.
+ */
+
+/**
+ * Table Manager Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1B80-0x1BBF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0B80-0x0BBF inclusive.
+ */
+#define TBL_MANAGER_CMD_MID 0x1B80
+#define TBL_MANAGER_SEND_HK_MID 0x1B81
+#define TBL_MANAGER_SEND_UPDATE_MID 0x1B82
+#define TBL_MANAGER_HK_TLM_MID 0x0B81
+
+/**
+ * MOONRANGER Common Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1C00-0x1C3F inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0C00-0x0C3F inclusive.
+ */
+#define MOONRANGER_GOAL_MID 0x0C00
+#define MOONRANGER_POSE_MID 0x0C01
+#define MOONRANGER_POINT_CLOUD_MID 0x0C02
+#define MOONRANGER_MESH_MID 0x0C03
+#define MOONRANGER_BODY_VELOCITY_MID 0x0C04
+#define MOONRANGER_WHEEL_VEL_CMD_MID 0x0C05
+#define MOONRANGER_DRIVE_ARC_MID 0x0C06
+
+#define MOONRANGER_SUNSEEKER_MID 0x0C07
+#define MOONRANGER_CMD_VEL_MID 0x0C08
+
+/* FAUXRANGER Message IDs (these messages originate from the Unreal Simulation)
+ */
+#define FAUXRANGER_F_L_CAM_INFO_MID 0x0C21   // front left camera info
+#define FAUXRANGER_F_R_CAM_INFO_MID 0x0C22   // front right camera info
+#define FAUXRANGER_B_L_CAM_INFO_MID 0x0C23   // back left camera info
+#define FAUXRANGER_B_R_CAM_INFO_MID 0x0C24   // back right camera info
+#define FAUXRANGER_F_L_CAM_DATA_MID 0x0C25   // front left camera data
+#define FAUXRANGER_F_R_CAM_DATA_MID 0x0C26   // front right camera data
+#define FAUXRANGER_B_L_CAM_DATA_MID 0x0C27   // back left camera data
+#define FAUXRANGER_B_R_CAM_DATA_MID 0x0C28   // back right camera data
+#define FAUXRANGER_IMU_MID 0x0C29
+#define FAUXRANGER_WHEELS_MID 0x0C2A
+#define FAUXRANGER_ODOM_MID 0x0C2B
+
+/***************************************************************************/
+/************************* Default cFS Apps ********************************/
+/***************************************************************************/
+
+/**
+ * cFS Telemetry Output Message IDs
+ * @note Message IDs are left to the default values because some of the
+ * addresses are hard coded in the repo. It is safer to leave them as it is.
  */
 #define TLM_OUTPUT_CMD_MID 0x1880
 #define TLM_OUTPUT_SEND_HK_MID 0x1881
@@ -124,74 +185,51 @@
 
 /**
  * Command Ingestion Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0A00-0x0AFF inclusive.
+ * @note Message IDs are left to the default values because some of the
+ * addresses are hard coded in the repo. It is safer to leave them as it is.
  */
 #define CMD_INGEST_CMD_MID 0x1884
 #define CMD_INGEST_SEND_HK_MID 0x1885
-
 #define CMD_INGEST_HK_TLM_MID 0x0884
 
 /**
  * Health and Safety Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0B00-0x0BFF inclusive.
+ * @note Message IDs are left to the default values because some of the
+ * addresses are hard coded in the repo. It is safer to leave them as it is.
  */
-#define HS_CMD_MID 0x18AE     /**< \brief Msg ID for cmds to HS               */
-#define HS_SEND_HK_MID 0x18AF /**< \brief Msg ID to request HS housekeeping*/
-#define HS_WAKEUP_MID 0x18B0  /**< \brief Msg ID to wake up HS */
-
+/** Msg ID for cmds to HS */
+#define HS_CMD_MID 0x18AE
+/** Msg ID to request HS housekeeping */
+#define HS_SEND_HK_MID 0x18AF
+/** Msg ID to wake up HS */
+#define HS_WAKEUP_MID 0x18B0
+/** HS Housekeeping Telemetry */
+#define HS_HK_TLM_MID 0x08AD
 
 /**
  * Scheduler Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0C00-0x0CFF inclusive.
+ * @note Message IDs are left to the default values because some of the
+ * addresses are hard coded into unit tests. It is safer to leave them as it is.
  */
-#define SCH_CMD_MID                    0x1895 /**< \brief SCH Ground Commands Message ID */
-#define SCH_SEND_HK_MID                0x1896 /**< \brief SCH Send Housekeeping Message ID */
-#define SCH_UNUSED_MID                 0x1897 /**< \brief SCH MDT Unused Message Message ID */
+/** SCH Ground Commands Message ID */
+#define SCH_CMD_MID 0x1895
+/** SCH Send Housekeeping Message ID */
+#define SCH_SEND_HK_MID 0x1896
+/** SCH MDT Unused Message Message ID */
+#define SCH_UNUSED_MID 0x1897
 /*
 #define SCH_SPARE1                     0x1898
 #define SCH_SPARE2                     0x1899
 */
 
-#define SCH_HK_TLM_MID                 0x0897 /**< \brief SCH Housekeeping Telemetry Message ID */
-#define SCH_DIAG_TLM_MID               0x0898 /**< \brief SCH Diagnostic Telemetry Message ID */
-/* 
+/** SCH Housekeeping Telemetry Message ID */
+#define SCH_HK_TLM_MID 0x0897
+/** SCH Diagnostic Telemetry Message ID */
+#define SCH_DIAG_TLM_MID 0x0898
+/*
 #define SCH_TLM_SPARE1                 0x0899
 #define SCH_TLM_SPARE2                 0x089A
 */
-
-
-
-/**
- * MOONRANGER Common Message IDs
- * @note  Message IDS in this section should fit within
- * 0x0D00-0x0DFF inclusive.
- */
-#define MOONRANGER_GOAL_MID 0x0C00
-#define MOONRANGER_POSE_MID 0x0C01
-#define MOONRANGER_POINT_CLOUD_MID 0x0C02
-#define MOONRANGER_MESH_MID 0x0C03
-#define MOONRANGER_BODY_VELOCITY_MID 0x0890
-#define MOONRANGER_WHEEL_VEL_CMD_MID 0x0891
-#define MOONRANGER_DRIVE_ARC_MID 0x0892
-
-#define MOONRANGER_SUNSEEKER_MID 0x0104
-#define MOONRANGER_CMD_VEL_MID 0x0105
-
-/* FAUXRANGER Message IDs (these messages originate from the Unreal Simulation) */
-#define FAUXRANGER_F_L_CAM_INFO_MID 0x0501 //front left camera info
-#define FAUXRANGER_F_R_CAM_INFO_MID 0x0502 //front right camera info
-#define FAUXRANGER_B_L_CAM_INFO_MID 0x0503 //back left camera info
-#define FAUXRANGER_B_R_CAM_INFO_MID 0x0504 //back right camera info
-#define FAUXRANGER_F_L_CAM_DATA_MID 0x0505 //front left camera data
-#define FAUXRANGER_F_R_CAM_DATA_MID 0x0506 //front right camera data
-#define FAUXRANGER_B_L_CAM_DATA_MID 0x0507 //back left camera data
-#define FAUXRANGER_B_R_CAM_DATA_MID 0x0508 //back right camera data
-#define FAUXRANGER_IMU_MID 0x0509
-#define FAUXRANGER_WHEELS_MID 0x0510
-#define FAUXRANGER_ODOM_MID 0x0511
 
 #endif /* _moonranger_msgids_h_ */
 

--- a/fsw/public_inc/tbl_manager_msgs.h
+++ b/fsw/public_inc/tbl_manager_msgs.h
@@ -25,15 +25,6 @@
 #define TBL_MANAGER_RECEIVE_UPDATE_CC 2
 
 /**
- * Table manager Message IDs
- */
-
-#define TBL_MANAGER_CMD_MID 0x18E6
-#define TBL_MANAGER_SEND_HK_MID 0x18E7
-#define TBL_MANAGER_SEND_UPDATE_MID 0x18E8
-#define TBL_MANAGER_HK_TLM_MID 0x08E7
-
-/**
  * Command data structure
  */
 


### PR DESCRIPTION
-Rewrote the bounds of the custom apps msg ids to be
within 0x1900 to 0x1FFF
-Left default cFS apps to have 0x18xx addresses
-Moved msgids from table manager msgs to moonranger msgids
-Add new camera_if CCs to send stereo msg

## 
Prevent bugs found [here](https://moonrangerclass.slack.com/archives/CMD1YU2Q2/p1637699801310100).
Root cause is that cFS only allows command ids to be within 0x1800 to 0x1FFF and telemetry to be within 0x0800 to 0x0FFF

## How has this been tested?
unit test and manually sent all CCs with GroundSystem to verify that apps can receive the command ids

Output:
```
1980-012-14:06:09.48954 ES Startup: PLANNER loaded and created
1980-012-14:06:09.48958 PLANNER App: Successfully loaded table.
EVS Port1 0/1/PLANNER 1: PLANNER App Initialized.
1980-012-14:06:09.48966 ES Startup: Loading file: /cf/vehicle_controller.so, APP: VEHICLE_CONTROLLER
1980-012-14:06:09.49002 ES Startup: VEHICLE_CONTROLLER loaded and created
1980-012-14:06:09.49006 Vehicle Controller: Config Table: 0.321950, l: 0.222200, h: 0.074500, r: 0.095500, vx: 0.000000, vy: 0.000000.
1980-012-14:06:09.49008 Kinematics Update: w: 0.321950 l: 0.222200 h: 0.074500 r: 0.095500 vx: 0.000000 vy: 0.000000
1980-012-14:06:09.49009 Initializing thresholds: r_t: 6.000000, x_dot: 0.050000, omega: 1.000000, psi_dot 0.500000
EVS Port1 0/1/VEHICLE_CONTROLLER 1: VEHICLE_CONTROLLER App Initialized.  Vehicle Controller App DEVELOPMENT BUILD 0.1.0, Last Official Release: v1.1.0
1980-012-14:06:09.49014 ES Startup: Loading file: /cf/pose_estimator.so, APP: POSE_ESTIMATOR
1980-012-14:06:09.49018 ES Startup: POSE_ESTIMATOR loaded and created
EVS Port1 0/1/POSE_ESTIMATOR 1: Pose Estimator App Initialized.  Pose Estimator App DEVELOPMENT BUILD 0.1.0, Last Official Release: v1.1.0
1980-012-14:06:09.54023 ES Startup: CFE_ES_Main entering APPS_INIT state
1980-012-14:06:09.54023 ES Startup: CFE_ES_Main entering OPERATIONAL state
EVS Port1 0/1/CFE_TIME 21: Stop FLYWHEEL
.EVS Port1 0/1/SCH 17: Slots skipped: slot = 2, count = 98
.EVS Port1 0/1/TLM_OUTPUT_APP 3: TO telemetry output enabled for IP 127.0.0.1
.EVS Port1 0/1/SCH 17: Slots skipped: slot = 2, count = 98
EVS Port1 0/1/CAMERA_IF 3: CAMERA_IF: NOOP command
EVS Port1 0/1/CAMERA_IF 4: CAMERA_IF: RESET command
EVS Port1 0/1/CAMERA_IF 5: CAMERA_IF: Image saved
EVS Port1 0/1/CAMERA_IF 10: CAMERA_IF: Successfully send stereo work img pairs
.EVS Port1 0/1/SCH 17: Slots skipped: slot = 2, count = 98
EVS Port1 0/1/POSE_ESTIMATOR 3: POSE: NOOP Command 0.1.0
EVS Port1 0/1/POSE_ESTIMATOR 1: POSE: RESET Command
.EVS Port1 0/1/MAPPER 3: MAPPER: NOOP command main+dev3
EVS Port1 0/1/MAPPER 4: MAPPER: RESET command
EVS Port1 0/1/SCH 17: Slots skipped: slot = 2, count = 98
EVS Port1 0/1/PLANNER 8: PLANNER: START command
.EVS Port1 0/1/PLANNER 3: PLANNER: NOOP command
EVS Port1 0/1/PLANNER 4: PLANNER: RESET command
1980-012-14:06:47.49012 PLANNER App: Fail to get table address: 0x4c00000e
EVS Port1 0/1/PLANNER 2: PLANNER APP: Error processing command packet: Status = 1275068430
EVS Port1 0/1/PLANNER 9: PLANNER: STOP command
.EVS Port1 0/1/VEHICLE_CONTROLLER 3: VEHICLE: NOOP Command 0.1.0
EVS Port1 0/1/VEHICLE_CONTROLLER 4: VEHICLE: RESET Command
```

Encountered error with PLANNER app but it has nothing to do with the SB msg. The CCs correctly triggers the process function. It is the process function that produced the error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
