### PR TITLE
Updated pointcloud message struct

### DIFF
--- a/fsw/public_inc/point_cloud_msg.h
+++ b/fsw/public_inc/point_cloud_msg.h
@@ -5,9 +5,9 @@
  * @brief     Type definition for Moonranger point cloud message
  * 
  * @version   1.0
- * @date      19 Oct 2021
+ * @date      4 Nov 2021
  * 
- * @authors 	Tenzin Crouch
+ * @authors 	Tenzin Crouch, Ankur Bodhe
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  * 
  ****************************************************************/
@@ -16,14 +16,38 @@
 #ifndef _point_cloud_msg_h_
 #define _point_cloud_msg_h_
 
-
+#include "cfe_sb.h"
+#include "common_types.h"
 /*************************************************************************/
 /*
 ** Type definition (MOONRANGER Point cloud)
 ** TODO: define actual structure
 */
 
-typedef MOONRANGER_NoArgsCmd_t MOONRANGER_Pcl_t;
+#define IMG_WIDTH  644
+#define IMG_HEIGHT 366
+
+typedef struct point_cloud_msg
+{
+    
+    CFE_TIME_SysTime_t  timestamp;
+    string  cameraLabel;
+    float32 pointCloud[IMG_WIDTH][IMG_HEIGHT][3];
+
+}MOONRANGER_Pcl_t;
+
+/**
+ * Type definition (MOONRANGER pointCloud telemetry)
+ * @note includes CFS TLM Header with timestamp
+ */
+typedef struct {
+  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+  MOONRANGER_Pcl_t pcl_data;
+} OS_PACK MOONRANGER_Pcl_Tlm_t;
+
+// Message sizes
+#define MOONRANGER_POSE_LNGTH sizeof(MOONRANGER_Pcl_t)
+#define MOONRANGER_POSE_TLM_LNGTH sizeof(MOONRANGER_Pcl_Tlm_t)
 
 #endif /* _point_cloud_msg_h_ */
 

--- a/fsw/public_inc/point_cloud_msg.h
+++ b/fsw/public_inc/point_cloud_msg.h
@@ -31,7 +31,7 @@ typedef struct point_cloud_msg
 {
     
     CFE_TIME_SysTime_t  timestamp;
-    string  cameraLabel;
+    char*  cameraLabel;
     float32 pointCloud[IMG_WIDTH][IMG_HEIGHT][3];
 
 }MOONRANGER_Pcl_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the PointCloud message structure. THis is done in accordance with the design documentation and discussion with the perception team. 
## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [X] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
