### PR TITLE
updated planner_msgs.h with counters for pose,mesh,goal in PLANNER_HkTlm_Payload_t

### DIFF
--- a/fsw/public_inc/planner_msgs.h
+++ b/fsw/public_inc/planner_msgs.h
@@ -13,21 +13,6 @@
  * @note		This file only contains app specific command and
  * 				telemetry message definitions and command codes.
  ****************************************************************/
-
-/*********************************************************************
- * INSTRUCTIONS
- *
- * This file should contain all the type definitions for app specific messages
- *such as housekeeping / telemetry.
- *
- * It should also contain definitions for all command messages and command
- *codes.
- *
- * All message IDs should be placed in moonranger_messageids.h in the
- *appropriately marked location
- *
- * DELETE THIS BLOCK ONCE COMPLETE
- *******************************************************************/
 #ifndef __planner_msgs_h
 #define _planner_msgs_h
 

--- a/fsw/public_inc/planner_msgs.h
+++ b/fsw/public_inc/planner_msgs.h
@@ -74,6 +74,10 @@ typedef struct
 {
     uint8              CommandErrorCounter;
     uint8              CommandCounter;
+	uint8			   GoalCounter;
+    uint8			   PoseCounter;
+    uint8			   ValidPoseCounter;
+    uint8			   MeshCounter;
     uint8              spare[2];
 } PLANNER_HkTlm_Payload_t;
 

--- a/fsw/public_inc/planner_msgs.h
+++ b/fsw/public_inc/planner_msgs.h
@@ -1,30 +1,31 @@
 /****************************************************************
- * 
+ *
  * @file      planner_msg.h
- * 
+ *
  * @brief     Message types for the planner app
- * 
+ *
  * @version   1.0
  * @date   		10/13/2021
- * 
+ *
  * @authors 	Abby Breitfeld
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
- * 
- * @note		This file only contains app specific command and 
+ *
+ * @note		This file only contains app specific command and
  * 				telemetry message definitions and command codes.
  ****************************************************************/
 
-
 /*********************************************************************
  * INSTRUCTIONS
- * 
- * This file should contain all the type definitions for app specific messages such as
- * housekeeping / telemetry.
- * 
- * It should also contain definitions for all command messages and command codes.
- * 
- * All message IDs should be placed in moonranger_messageids.h in the appropriately marked location
- * 
+ *
+ * This file should contain all the type definitions for app specific messages
+ *such as housekeeping / telemetry.
+ *
+ * It should also contain definitions for all command messages and command
+ *codes.
+ *
+ * All message IDs should be placed in moonranger_messageids.h in the
+ *appropriately marked location
+ *
  * DELETE THIS BLOCK ONCE COMPLETE
  *******************************************************************/
 #ifndef __planner_msgs_h
@@ -33,36 +34,33 @@
 #include "cfe_sb.h"
 #include "common_types.h"
 
-
 /**
  * PLANNER command codes
  */
-#define PLANNER_NOOP_CC                 0
-#define PLANNER_RESET_COUNTERS_CC       1
-#define PLANNER_PROCESS_CC              2
-#define PLANNER_START_CC		3
-#define PLANNER_STOP_CC			4
-
+#define PLANNER_NOOP_CC 0
+#define PLANNER_RESET_COUNTERS_CC 1
+#define PLANNER_PROCESS_CC 2
+#define PLANNER_START_CC 3
+#define PLANNER_STOP_CC 4
 
 /**
  * Type definition (generic "no arguments" command)
  */
-typedef struct
-{
-   uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+typedef struct {
+    uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 
 } PLANNER_NoArgsCmd_t;
 
 /**
  * The following commands all share the "NoArgs" format
  *
- * They are each given their own type name matching the command name, which_open_mode
- * allows them to change independently in the future without changing the prototype
- * of the handler function
+ * They are each given their own type name matching the command name,
+ * which_open_mode allows them to change independently in the future without
+ * changing the prototype of the handler function
  */
-typedef PLANNER_NoArgsCmd_t      PLANNER_Noop_t;
-typedef PLANNER_NoArgsCmd_t      PLANNER_ResetCounters_t;
-typedef PLANNER_NoArgsCmd_t      PLANNER_Process_t;
+typedef PLANNER_NoArgsCmd_t PLANNER_Noop_t;
+typedef PLANNER_NoArgsCmd_t PLANNER_ResetCounters_t;
+typedef PLANNER_NoArgsCmd_t PLANNER_Process_t;
 
 /*************************************************************************/
 
@@ -70,24 +68,21 @@ typedef PLANNER_NoArgsCmd_t      PLANNER_Process_t;
  * Type definition (PLANNER App housekeeping)
  */
 
-typedef struct
-{
-    uint8              CommandErrorCounter;
-    uint8              CommandCounter;
-	uint8			   GoalCounter;
-    uint8			   PoseCounter;
-    uint8			   ValidPoseCounter;
-    uint8			   MeshCounter;
-    uint8              spare[2];
+typedef struct {
+    uint8 CommandErrorCounter;
+    uint8 CommandCounter;
+    uint8 GoalCounter;
+    uint8 PoseCounter;
+    uint8 ValidPoseCounter;
+    uint8 MeshCounter;
+
 } PLANNER_HkTlm_Payload_t;
 
-typedef struct
-{
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
-    PLANNER_HkTlm_Payload_t  Payload;
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    PLANNER_HkTlm_Payload_t Payload;
 
 } OS_PACK PLANNER_HkTlm_t;
-
 
 #endif /* _planner_msgs_h */
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
A PR to add counters to the HKTlm_Payload_t struct in Planner_msgs.h.
## Description
<!--- Describe your changes in detail -->

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the `CONTRIBUTING.md` file
- [X] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [X] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
