### PR TITLE
Add message to prompt stereo reconstructor to load new camera calibration from common tables

### DIFF
--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -15,6 +15,7 @@
 /*** STEREO App command codes*/
 #define STEREO_NOOP_CC 0
 #define STEREO_RESET_COUNTERS_CC 1
+#define STEREO_RECEIVE_CAMERA_CALIB_CC 2
 
 /*************************************************************************/
 /*** Type definition (generic "no arguments" command)*/
@@ -30,6 +31,7 @@ typedef struct {
 typedef STEREO_NoArgsCmd_t STEREO_Noop_t;
 typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
 typedef STEREO_NoArgsCmd_t STEREO_Process_t;
+typedef STEREO_NoArgsCmd_t STEREO_Receive_Camera_Calib_t;
 
 /*************************************************************************/ 
 /** Type definition (STEREO App housekeeping)*/


### PR DESCRIPTION
## Description
Adds a new command code to the stereo reconstructor app that prompts stereo reconstructor to fetch the latest camera calibration from the common tables app

## 
Required for merging https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/204 to close https://github.com/PlanetaryRobotics/moonranger-rover-flight/issues/51

## How has this been tested?
Tested as part of https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/204

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
