### PR TITLE
Add buffer types to each message related to the planner

### DIFF
--- a/fsw/public_inc/drive_arc_msg.h
+++ b/fsw/public_inc/drive_arc_msg.h
@@ -23,6 +23,7 @@
  * Type definition (MOONRANGER drive arc packet)
  */
 typedef struct {
+  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_SysTime_t timeStamp; 
   float32            speed;    // m/s
   float32            duration; // seconds
@@ -38,6 +39,16 @@ typedef struct {
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
   MOONRANGER_DriveArc_t data;
 } OS_PACK MOONRANGER_DriveArc_Tlm_t;
+
+/**
+ * Buffer to hold drive arc data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union
+{
+    CFE_SB_Msg_t               MsgHdr;
+    MOONRANGER_DriveArc_Tlm_t  DriveArcTlm;
+} MOONRANGER_DriveArcBuffer_t;
 
 // Message sizes
 #define MOONRANGER_DRIVE_ARC_LNGTH sizeof(MOONRANGER_DriveArc_t)

--- a/fsw/public_inc/drive_arc_msg.h
+++ b/fsw/public_inc/drive_arc_msg.h
@@ -23,7 +23,6 @@
  * Type definition (MOONRANGER drive arc packet)
  */
 typedef struct {
-  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_SysTime_t timeStamp; 
   float32            speed;    // m/s
   float32            duration; // seconds

--- a/fsw/public_inc/goal_msg.h
+++ b/fsw/public_inc/goal_msg.h
@@ -43,6 +43,16 @@ typedef struct {
   MOONRANGER_Goal_t data;
 } OS_PACK MOONRANGER_Goal_Tlm_t;
 
+/**
+ * Buffer to hold goal data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union
+{
+    CFE_SB_Msg_t           MsgHdr;
+    MOONRANGER_Goal_Tlm_t  GoalTlm;
+} MOONRANGER_GoalBuffer_t;
+
 // Message sizes
 #define MOONRANGER_GOAL_LNGTH sizeof(MOONRANGER_Goal_t)
 #define MOONRANGER_GOAL_TLM_LNGTH sizeof(MOONRANGER_Goal_Tlm_t)

--- a/fsw/public_inc/planner_msgs.h
+++ b/fsw/public_inc/planner_msgs.h
@@ -69,6 +69,16 @@ typedef struct {
 
 } OS_PACK PLANNER_HkTlm_t;
 
+/**
+ * Buffer to hold telemetry data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union
+{
+    CFE_SB_Msg_t         MsgHdr;
+    PLANNER_HkTlm_t      HkTlm;
+} PLANNER_HkBuffer_t;
+
 #endif /* _planner_msgs_h */
 
 /************************/

--- a/fsw/public_inc/pose_msg.h
+++ b/fsw/public_inc/pose_msg.h
@@ -46,6 +46,16 @@ typedef struct {
   MOONRANGER_Pose_t pose_data;
 } OS_PACK MOONRANGER_Pose_Tlm_t;
 
+/**
+ * Buffer to hold pose data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union
+{
+    CFE_SB_Msg_t           MsgHdr;
+    MOONRANGER_Pose_Tlm_t  PoseTlm;
+} MOONRANGER_PoseBuffer_t;
+
 // Message sizes
 #define MOONRANGER_POSE_LNGTH sizeof(MOONRANGER_Pose_t)
 #define MOONRANGER_POSE_TLM_LNGTH sizeof(MOONRANGER_Pose_Tlm_t)


### PR DESCRIPTION
Added buffer types to the planner messages, drive arc messages, and goal and pose messages so they can correctly use CCSDS protocol across apps.

## How has this been tested?
Built and ran the planner app and associated unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
