### PR TITLE
Scratch/move all buffers to messages

### DIFF
--- a/fsw/public_inc/camera_if_msgs.h
+++ b/fsw/public_inc/camera_if_msgs.h
@@ -76,4 +76,21 @@ typedef struct
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK CAMERA_IF_SendStereoImgTlm_t;
 
+/*
+ * Buffer to hold telemetry data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union
+{
+  CFE_SB_Msg_t MsgHdr;
+  CAMERA_IF_HkTlm_t HkTlm;
+} CAMERA_IF_HkBuffer_t;
+
+typedef union
+{
+  CFE_SB_Msg_t MsgHdr;
+  CAMERA_IF_ImgSavedTlm_t ImgSavedTlm;
+} CAMERA_IF_ImgSavedBuffer_t;
+
+
 #endif /* _camera_if_msgs_h */

--- a/fsw/public_inc/cmd_ingest_msgs.h
+++ b/fsw/public_inc/cmd_ingest_msgs.h
@@ -65,6 +65,23 @@ typedef struct
     uint8                  TlmHeader[CFE_SB_TLM_HDR_SIZE];
     CMD_INGEST_HkTlm_Payload_t Payload;
 } OS_PACK CMD_INGEST_HkTlm_t;
+/*
+ * Declaring the CMD_INGEST_IngestBuffer as a union
+ * ensures it is aligned appropriately to
+ * store a CFE_SB_Msg_t type.
+ */
+typedef union
+{
+    CFE_SB_Msg_t MsgHdr;
+    uint8        bytes[CMD_INGEST_MAX_INGEST];
+    uint16       hwords[2];
+} CMD_INGEST_IngestBuffer_t;
+
+typedef union
+{
+    CFE_SB_Msg_t   MsgHdr;
+    CMD_INGEST_HkTlm_t HkTlm;
+} CMD_INGEST_HkTlm_Buffer_t;
 
 #define CMD_INGEST_HK_TLM_LNGTH sizeof(CMD_INGEST_HkTlm_t)
 

--- a/fsw/public_inc/mapper_msgs.h
+++ b/fsw/public_inc/mapper_msgs.h
@@ -53,6 +53,14 @@ typedef struct
 	MAPPER_HkTlm_Payload_t	Payload;
 } OS_PACK MAPPER_HkTlm_t;
 
+/**
+ * Type definition - buffer for telemetry data before sending
+ */
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    MAPPER_HkTlm_t HkTlm;
+} MAPPER_HkBuffer_t;
+
 #endif /* _mapper_msgs_h_*/
 
 /* EOF */

--- a/fsw/public_inc/pose_estimator_msgs.h
+++ b/fsw/public_inc/pose_estimator_msgs.h
@@ -50,6 +50,13 @@ typedef struct
     POSE_HkTlm_Payload_t  Payload;
 
 } OS_PACK POSE_HkTlm_t;
+
+typedef struct 
+{
+	CFE_SB_Msg_t	MsgHdr;
+	POSE_HkTlm_t	HkTlm;
+} POSE_HkBuffer_t;
+
 #endif //_pose_estimator_msgs_h_ header
 
 /* EOF */

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -44,8 +44,17 @@ typedef struct {
     uint8 CommandCounter;
     uint8 spare[2];
 } STEREO_HkTlm_Payload_t;
+
 typedef struct {
     uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
     STEREO_HkTlm_Payload_t Payload;
 } OS_PACK STEREO_HkTlm_t;
+/*
+ * Buffer to hold telemetry data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    STEREO_HkTlm_t HkTlm;
+} STEREO_HkBuffer_t;
 #endif /* _stereo_reconstructor_msg_h_ */

--- a/fsw/public_inc/tbl_manager_msgs.h
+++ b/fsw/public_inc/tbl_manager_msgs.h
@@ -53,6 +53,14 @@ typedef struct {
     TBL_MANAGER_HkTlm_Payload_t Payload;
 } OS_PACK TBL_MANAGER_HkTlm_t;
 
+/**
+ * Type definition - buffer for telemetry data before sending
+ */
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    TBL_MANAGER_HkTlm_t HkTlm;
+} TBL_MANAGER_HkBuffer_t;
+
 #endif /* _tbl_manager_msg_h_ */
 
 /* EOF */

--- a/fsw/public_inc/tlm_output_msgs.h
+++ b/fsw/public_inc/tlm_output_msgs.h
@@ -37,6 +37,7 @@ typedef struct
     uint8 spareToAlign[2];
 } TLM_OUTPUT_HkTlm_Payload_t;
 
+
 typedef struct
 {
     uint8                  TlmHeader[CFE_SB_TLM_HDR_SIZE];
@@ -146,6 +147,17 @@ typedef struct
     TLM_OUTPUT_EnableOutput_Payload_t Payload;
 } TLM_OUTPUT_EnableOutput_t;
 
+typedef union
+{
+    CFE_SB_Msg_t   MsgHdr;
+    TLM_OUTPUT_HkTlm_t HkTlm;
+} TLM_OUTPUT_HkTlm_Buffer_t;
+
+typedef union
+{
+    CFE_SB_Msg_t       MsgHdr;
+    TLM_OUTPUT_DataTypes_t DataTypes;
+} TLM_OUTPUT_DataTypes_Buffer_t;
 /******************************************************************************/
 
 #endif /* _tlm_output_msg_h_ */


### PR DESCRIPTION
Tried to move all the buffer messages for housekeeping and others to the msg files. 

Tested by building. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
