### PR TITLE
added motor-msp reply msgs

### DIFF
--- a/fsw/public_inc/motor_controller_msgs.h
+++ b/fsw/public_inc/motor_controller_msgs.h
@@ -1,13 +1,13 @@
 /****************************************************************
  * 
- * @file      TODO
+ * @file      motor_controller_msgs.h
  * 
- * @brief     TODO
+ * @brief     messages send by motor controller
  * 
- * @version   TODO
- * @date   		TODO
+ * @version   1.0
+ * @date   		12/4/2021
  * 
- * @authors 	TODO
+ * @authors 	Michael Lang
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  * 
  * @note		This file only contains app specific command and 
@@ -15,23 +15,25 @@
  * 
  ****************************************************************/
 
-
-/*********************************************************************
- * INSTRUCTIONS
- * 
- * This file should contain all the type definitions for app specific messages such as
- * housekeeping / telemetry.
- * 
- * It should also contain definitions for all command messages and command codes.
- * 
- * All message IDs should be placed in moonranger_messageids.h in the appropriately marked location
- * 
- * DELETE THIS BLOCK ONCE COMPLETE
- *******************************************************************/
-
 #ifndef _motor_controller_msgs_h
 #define _motor_controller_msgs_h
 
+typedef struct {
+    volatile int32_t motor_hall_sensor;        // the ticks from hall sensor
+    volatile int32_t motor_desired_velocity;   // The commanded velocity
+    volatile int32_t motor_actual_velocity;    // The actual velocity
+    volatile int32_t motor_pwm;                // The motor pwm duty cycle
+    volatile int32_t motor_current;            // The current drawn by the motor
+    volatile int32_t motor_p_gain;               // The P gain of the motor scaled
+    volatile int32_t motor_i_gain;               // The I gain of the motor scaled
+    volatile int32_t motor_d_gain;               // The D gain of the motor scaled
+    volatile uint8_t motor_brake;              // The brake status of the motor
+    uint8_t _padding[3];
+} motor_health_msg_t;
+
+typedef struct{
+    motor_health_msg_t motors[5];
+}motor_health_msg_all_t;
 
 
 


### PR DESCRIPTION
This pull requests add the structs for the reply messages of the motor controller. 
## Description
Added motor_health_msg and motor_health_msg_all

## How has this been tested?
This had been tested with the motor-msp code in flight repo and specifically the motor-msp-uart branch

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
