### PR TITLE
Added buffer for current wheel velocity message

### DIFF
--- a/fsw/public_inc/wheel_velocity_current_msg.h
+++ b/fsw/public_inc/wheel_velocity_current_msg.h
@@ -17,14 +17,15 @@
 
 #include "cfe_sb.h"
 #include "common_types.h"
+typedef float float32;
 
 /* The Incoming wheel velocity packet */
 typedef struct {
     CFE_TIME_SysTime_t timeStamp;
-    float64 leftFront;    // rad/s
-    float64 rightFront;   // rad/s
-    float64 leftBack;     // rad/s
-    float64 rightBack;    // rad/s
+    float32 leftFront;    // rad/s
+    float32 rightFront;   // rad/s
+    float32 leftBack;     // rad/s
+    float32 rightBack;    // rad/s
 } MOONRANGER_WheelVelocityCurrent_t;
 
 /* Type definition for wheel velocity telemetry */
@@ -32,6 +33,17 @@ typedef struct {
 	uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 	MOONRANGER_WheelVelocityCurrent_t data;
 } OS_PACK MOONRANGER_WheelVelocityCurrent_Tlm_t;
+
+
+/**
+ * Buffer to hold the wheel packet data prior to sending
+ */
+
+typedef union
+{
+	CFE_SB_Msg_t MsgHdr;
+	MOONRANGER_WheelVelocityCurrent_Tlm_t WheelTlm;
+} MOONRANGER_WheelBuffer_t;
 
 /* Message sizes */
 #define MOONRANGER_WHEEL_VEL_CUR_LNGTH sizeof(MOONRANGER_WheelVelocityCurrent_t)


### PR DESCRIPTION
Needed for completing the  movement of wheel buffers

## How has this been tested?
Built and run successfully

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
