### PR TITLE
Wheel velocity name disambiguation

### DIFF
--- a/fsw/public_inc/body_velocity_msg.h
+++ b/fsw/public_inc/body_velocity_msg.h
@@ -18,6 +18,8 @@
 #include "cfe_sb.h"
 #include "common_types.h"
 
+typedef float float32;
+
 /*************************************************************************/
 /**
  * Type definition (MOONRANGER body velocity packet)

--- a/fsw/public_inc/drive_arc_msg.h
+++ b/fsw/public_inc/drive_arc_msg.h
@@ -18,6 +18,8 @@
 #include "cfe_sb.h"
 #include "common_types.h"
 
+typedef float float32;
+
 /*************************************************************************/
 /**
  * Type definition (MOONRANGER drive arc packet)

--- a/fsw/public_inc/wheel_velocity_current_msg.h
+++ b/fsw/public_inc/wheel_velocity_current_msg.h
@@ -43,7 +43,7 @@ typedef union
 {
 	CFE_SB_Msg_t MsgHdr;
 	MOONRANGER_WheelVelocityCurrent_Tlm_t WheelTlm;
-} MOONRANGER_WheelBuffer_t;
+} MOONRANGER_WheelCurrentBuffer_t;
 
 /* Message sizes */
 #define MOONRANGER_WHEEL_VEL_CUR_LNGTH sizeof(MOONRANGER_WheelVelocityCurrent_t)


### PR DESCRIPTION
The name of both wheel velcoity buffers was the same, and needed to be updated. 
https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/217 is the corresponding PR in the flight repo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
