### PR TITLE
Scratch/colorize output strings

### DIFF
--- a/fsw/public_inc/moonranger_output_strings.h
+++ b/fsw/public_inc/moonranger_output_strings.h
@@ -17,36 +17,41 @@
 #define ESCAPE    "\033["
 #define TERMINATE "m"
 /* Reset color back to normal with ANSI color codes */
-#define RESET "0"    TERMINATE
-#define END   ESCAPE RESET
+#define RESET_COLOR "0"    TERMINATE
+#define END_COLOR   ESCAPE RESET_COLOR
 
 /* Define ANSI color codes for strings */
-#define RED            "31" TERMINATE
-#define RED_BOLD       "1;" RED
-#define GREEN          "32" TERMINATE
-#define GREEN_BOLD     "1;" GREEN
-#define YELLOW         "33" TERMINATE
-#define YELLOW_BOLD    "1;" YELLOW
-#define BLUE           "34" TERMINATE
-#define BLUE_BOLD      "1;" BLUE
-#define MAGENTA        "35" TERMINATE
-#define MAGENTA_BOLD   "1;" MAGENTA
-#define CYAN           "36" TERMINATE
-#define CYAN_BOLD      "1;" CYAN
+#define COLOR_RED            "31" TERMINATE
+#define COLOR_RED_BOLD       "1;" COLOR_RED
+#define COLOR_GREEN          "32" TERMINATE
+#define GREEN_BOLD           "1;" COLOR_GREEN
+#define COLOR_YELLOW         "33" TERMINATE
+#define YELLOW_BOLD          "1;" COLOR_YELLOW
+#define COLOR_BLUE           "34" TERMINATE
+#define BLUE_BOLD            "1;" COLOR_BLUE
+#define COLOR_MAGENTA        "35" TERMINATE
+#define MAGENTA_BOLD         "1;" COLOR_MAGENTA
+#define COLOR_CYAN           "36" TERMINATE
+#define CYAN_BOLD            "1;" COLOR_CYAN
 
 
 /* Define macros to process different color strings */
-#define RED_STRING(string)          ESCAPE RED          string END
-#define RED_BOLD_STRING(string)     ESCAPE RED_BOLD     string END
-#define GREEN_STRING(string)        ESCAPE GREEN        string END
-#define GREEN_BOLD_STRING(string)   ESCAPE GREEN_BOLD   string END
-#define YELLOW_STRING(string)       ESCAPE YELLOW       string END
-#define YELLOW_BOLD_STRING(string)  ESCAPE YELLOW_BOLD  string END
-#define BLUE_STRING(string)         ESCAPE BLUE         string END
-#define BLUE_BOLD_STRING(string)    ESCAPE BLUE_BOLD    string END
-#define MAGENTA_STRING(string)      ESCAPE MAGENTA      string END
-#define MAGENTA_BOLD_STRING(string) ESCAPE MAGENTA_BOLD string END
-#define CYAN_STRING(string)         ESCAPE CYAN         string END
-#define CYAN_BOLD_STRING(string)    ESCAPE CYAN_BOLD    string END
+#define RED_STRING(string)          ESCAPE COLOR_RED          string END_COLOR
+#define RED_BOLD_STRING(string)     ESCAPE COLOR_RED_BOLD     string END_COLOR
+#define GREEN_STRING(string)        ESCAPE COLOR_GREEN        string END_COLOR
+#define GREEN_BOLD_STRING(string)   ESCAPE GREEN_BOLD         string END_COLOR
+#define YELLOW_STRING(string)       ESCAPE COLOR_YELLOW       string END_COLOR
+#define YELLOW_BOLD_STRING(string)  ESCAPE YELLOW_BOLD        string END_COLOR
+#define BLUE_STRING(string)         ESCAPE COLOR_BLUE         string END_COLOR
+#define BLUE_BOLD_STRING(string)    ESCAPE BLUE_BOLD          string END_COLOR
+#define MAGENTA_STRING(string)      ESCAPE COLOR_MAGENTA      string END_COLOR
+#define MAGENTA_BOLD_STRING(string) ESCAPE MAGENTA_BOLD       string END_COLOR
+#define CYAN_STRING(string)         ESCAPE COLOR_CYAN         string END_COLOR
+#define CYAN_BOLD_STRING(string)    ESCAPE CYAN_BOLD          string END_COLOR
+
+/* Define macros to represent the type of information we are presenting */
+#define MOON_ERROR_INFO(string)   RED_STRING(string)
+#define MOON_WARNING_INFO(string) YELLOW_STRING(string)
+#define MOON_SUCCESS_INFO(string) GREEN_STRING(string)
 
 #endif //_moonranger_output_strings_h_ header

--- a/fsw/public_inc/moonranger_output_strings.h
+++ b/fsw/public_inc/moonranger_output_strings.h
@@ -1,0 +1,52 @@
+/****************************************************************
+ * 
+ * @file 		moonranger_msg_strings.h
+ * 
+ * @brief 		Header file specifying macros to use in order to create a string of a certain color on output console
+ * 
+ * @version 	1.0
+ * @date 		12/06/2021
+ * 
+ * @authors 	Ben Kolligs, ...
+ * @author 		Carnegie Mellon University, Planetary Robotics Lab
+ * 
+ ****************************************************************/
+#ifndef _moonranger_output_strings_h_
+#define _moonranger_output_strings_h_
+
+#define ESCAPE    "\033["
+#define TERMINATE "m"
+/* Reset color back to normal with ANSI color codes */
+#define RESET "0"    TERMINATE
+#define END   ESCAPE RESET
+
+/* Define ANSI color codes for strings */
+#define RED            "31" TERMINATE
+#define RED_BOLD       "1;" RED
+#define GREEN          "32" TERMINATE
+#define GREEN_BOLD     "1;" GREEN
+#define YELLOW         "33" TERMINATE
+#define YELLOW_BOLD    "1;" YELLOW
+#define BLUE           "34" TERMINATE
+#define BLUE_BOLD      "1;" BLUE
+#define MAGENTA        "35" TERMINATE
+#define MAGENTA_BOLD   "1;" MAGENTA
+#define CYAN           "36" TERMINATE
+#define CYAN_BOLD      "1;" CYAN
+
+
+/* Define macros to process different color strings */
+#define RED_STRING(string)          ESCAPE RED          string END
+#define RED_BOLD_STRING(string)     ESCAPE RED_BOLD     string END
+#define GREEN_STRING(string)        ESCAPE GREEN        string END
+#define GREEN_BOLD_STRING(string)   ESCAPE GREEN_BOLD   string END
+#define YELLOW_STRING(string)       ESCAPE YELLOW       string END
+#define YELLOW_BOLD_STRING(string)  ESCAPE YELLOW_BOLD  string END
+#define BLUE_STRING(string)         ESCAPE BLUE         string END
+#define BLUE_BOLD_STRING(string)    ESCAPE BLUE_BOLD    string END
+#define MAGENTA_STRING(string)      ESCAPE MAGENTA      string END
+#define MAGENTA_BOLD_STRING(string) ESCAPE MAGENTA_BOLD string END
+#define CYAN_STRING(string)         ESCAPE CYAN         string END
+#define CYAN_BOLD_STRING(string)    ESCAPE CYAN_BOLD    string END
+
+#endif //_moonranger_output_strings_h_ header


### PR DESCRIPTION
Adds macros that will color a string that is published to the terminal. 

## Description
Colors offered: 
* Red
* Green
* Yellow
* Blue
* Magenta
* Cyan
There are normal font and bold fonts available for each color. 

This change will assist sorting through visual noise during cFS startup. 

## How has this been tested?
See screen shot for successful test. 

## Screenshots (if appropriate):
This screenshot displays each color
![image](https://user-images.githubusercontent.com/29968424/144927676-e3cb82ae-e2cd-4ffc-bcc2-89a9d130630c.png)

And this screenshot displays why this is useful: 
![image](https://user-images.githubusercontent.com/29968424/144927721-2c20e4a0-3180-4ba1-afdf-70146cd45825.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
