### PR TITLE
Messages Modification(Logger)

### DIFF
--- a/fsw/public_inc/logger_msg.h
+++ b/fsw/public_inc/logger_msg.h
@@ -45,7 +45,7 @@ typedef struct {
     uint8 CommandErrorCounter;
     uint8 CommandCounter;
     uint8 LogMsgCounter;
-    uint8 spare[2];
+    uint8 spare;
 } LOGGER_HkTlm_Payload_t;
 
 typedef struct {

--- a/fsw/public_inc/logger_msg.h
+++ b/fsw/public_inc/logger_msg.h
@@ -1,0 +1,56 @@
+/**
+ * @file
+ *
+ * Define LOGGER App  Messages and info
+ */
+
+#ifndef LOGGER_MSG_H
+#define LOGGER_MSG_H
+
+/*
+** LOGGER App command codes
+*/
+#define LOGGER_NOOP_CC 0
+#define LOGGER_RESET_COUNTERS_CC 1
+#define LOGGER_G_CC 1
+#define LOGGER_P_CC 1
+
+/*************************************************************************/
+
+/*
+** Type definition (generic "no arguments" command)
+*/
+typedef struct {
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief Command header */
+} LOGGER_NoArgsCmd_t;
+
+/*
+** The following commands all share the "NoArgs" format
+**
+** They are each given their own type name matching the command name, which
+** allows them to change independently in the future without changing the
+*prototype
+** of the handler function
+*/
+typedef LOGGER_NoArgsCmd_t LOGGER_NoopCmd_t;
+typedef LOGGER_NoArgsCmd_t LOGGER_ResetCountersCmd_t;
+typedef LOGGER_NoArgsCmd_t LOGGER_ProcessCmd_t;
+
+/*************************************************************************/
+/*
+** Type definition (LOGGER App housekeeping)
+*/
+
+typedef struct {
+    uint8 CommandErrorCounter;
+    uint8 CommandCounter;
+    uint8 LogMsgCounter;
+    uint8 spare[2];
+} LOGGER_HkTlm_Payload_t;
+
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief Telemetry header */
+    LOGGER_HkTlm_Payload_t Payload;       /**< \brief Telemetry payload */
+} LOGGER_HkTlm_t;
+
+#endif /* LOGGER_MSG_H */

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -143,6 +143,18 @@
 #define TBL_MANAGER_HK_TLM_MID 0x0B81
 
 /**
+ * Table Manager Message IDs
+ * @note Command message IDs in this section should fit within
+ * 0x1BC0-0x1BFF inclusive.
+ * @note Telemetry message IDs in this section should fit within
+ * 0x0BC0-0x0BFF inclusive.
+ */
+
+#define LOGGER_CMD_MID      0x1BC0
+#define LOGGER_SEND_HK_MID  0x1BC1
+#define LOGGER_HK_TLM_MID   0x0BC0
+
+/**
  * MOONRANGER Common Message IDs
  * @note Command message IDs in this section should fit within
  * 0x1C00-0x1C3F inclusive.
@@ -212,16 +224,6 @@
 #define HS_WAKEUP_MID 0x18B0
 /** HS Housekeeping Telemetry */
 #define HS_HK_TLM_MID 0x08AD
-
-/**
- * Logger App Message IDs
- * @note Message IDs are left to the default values because some of the
- * addresses are hard coded into unit tests. It is safer to leave them as it is.
- */
-
-#define LOGGER_CMD_MID      0x19F1
-#define LOGGER_SEND_HK_MID  0x19F2
-#define LOGGER_HK_TLM_MID   0x09F3
 
 /**
  * Scheduler Message IDs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This branch contains different Msgids for the Logger App to avoid having duplicates and now also contains a msgs.h file that used to be in the logger folder.

## 
<!--- This change was required to make the formatting consistent and to avoid msg id duplicates
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!---These changes have not been tested in any major way other than just being built and run as a part of a greater test.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read and followed the `CONTRIBUTING.md` file
- [ x] I have applied the .clang-format file to my changes
- [ x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the design documentation 
- [ x] I have updated any relevant parameters in the internal ICD
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ x] New and existing unit tests pass locally with my changes
- [ x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
