### PR TITLE
Blind Nav flag in goal message

### DIFF
--- a/fsw/public_inc/goal_msg.h
+++ b/fsw/public_inc/goal_msg.h
@@ -31,7 +31,7 @@ typedef struct {
   float32 x_radius;    // meters
   float32 y_radius;    // meters
   float32 orientation; // radians
-  bool blind;          // switch for blind navigation
+  bool blind_nav;      // switch for blind navigation
 
 } MOONRANGER_Goal_t;
 

--- a/fsw/public_inc/goal_msg.h
+++ b/fsw/public_inc/goal_msg.h
@@ -31,6 +31,7 @@ typedef struct {
   float32 x_radius;    // meters
   float32 y_radius;    // meters
   float32 orientation; // radians
+  bool blind;          // switch for blind navigation
 
 } MOONRANGER_Goal_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a blind nav flag in the goal message (tbd if it will be used, but we agreed it would be good to have it in there for future).

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Needed before I can merge in blind navigation code to the flight repo.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design documentation 
- [x] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
