### PR TITLE
Update stereo message definitions

### DIFF
--- a/fsw/public_inc/pose_estimator_msgs.h
+++ b/fsw/public_inc/pose_estimator_msgs.h
@@ -1,62 +1,61 @@
 /****************************************************************
- * 
+ *
  * @file 		pe_msg.h
- * 
+ *
  * @brief 		The message definitions for the pose estimation app
- * 
+ *
  * @version 	1.0
  * @date 		10/8/2021
- * 
+ *
  * @authors 	Ben Kolligs, ...
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
- * 
- * @note		This file only contains app specific command and 
+ *
+ * @note		This file only contains app specific command and
  * 				telemetry message definitions and command codes.
- * 
+ *
  ****************************************************************/
 #ifndef _pose_estimator_msgs_h_
 #define _pose_estimator_msgs_h_
 
-
 #include <cinttypes>
+#ifdef __cplusplus
 extern "C" {
-	#include "cfe.h"
+#endif
+#include "cfe.h"
+#ifdef __cplusplus
 }
-
+#endif
 
 /**
  * app command codes
  */
-#define POSE_NOOP_CC               0
-#define POSE_RESET_COUNTERS_CC     1
-#define POSE_UPDATE_PARAMS_CC      2
+#define POSE_NOOP_CC 0
+#define POSE_RESET_COUNTERS_CC 1
+#define POSE_UPDATE_PARAMS_CC 2
 
 /***************************************************
 /*
 ** Type definition Housekeeping Telemetry
 */
-typedef struct
-{
-    uint8              CommandCounter;
-    uint8              CommandErrorCounter;
-    uint8              WheelCounter;
-    uint8              ArcCounter;
-    uint8              spare[2];
+typedef struct {
+    uint8 CommandCounter;
+    uint8 CommandErrorCounter;
+    uint8 WheelCounter;
+    uint8 ArcCounter;
+    uint8 spare[2];
 } POSE_HkTlm_Payload_t;
 
-typedef struct
-{
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
-    POSE_HkTlm_Payload_t  Payload;
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    POSE_HkTlm_Payload_t Payload;
 
 } OS_PACK POSE_HkTlm_t;
 
-typedef struct 
-{
-	CFE_SB_Msg_t	MsgHdr;
-	POSE_HkTlm_t	HkTlm;
+typedef struct {
+    CFE_SB_Msg_t MsgHdr;
+    POSE_HkTlm_t HkTlm;
 } POSE_HkBuffer_t;
 
-#endif //_pose_estimator_msgs_h_ header
+#endif   //_pose_estimator_msgs_h_ header
 
 /* EOF */

--- a/fsw/public_inc/pose_estimator_msgs.h
+++ b/fsw/public_inc/pose_estimator_msgs.h
@@ -17,7 +17,6 @@
 #ifndef _pose_estimator_msgs_h_
 #define _pose_estimator_msgs_h_
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +24,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
 
 /**
  * app command codes
@@ -61,6 +59,6 @@ typedef struct {
 #define POSE_HKTLM_PAYLOAD_LNGTH sizeof(POSE_HkTlm_Payload_t)
 #define POSE_HKTLM_LNGTH sizeof(POSE_HkTlm_t)
 
-#endif //_pose_estimator_msgs_h_ header
+#endif   //_pose_estimator_msgs_h_ header
 
 /* EOF */

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -58,6 +58,13 @@ typedef struct {
 typedef struct
 {
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+} OS_PACK STEREO_SendHkTlm_t;
+
+#define STEREO_SEND_HK_TLM_LNGTH sizeof(STEREO_SendHkTlm_t)
+
+typedef struct
+{
+  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendPclMsgTlm_t;
 
 #define STEREO_SEND_PCL_TLM_LNGTH sizeof(STEREO_SendPclMsgTlm_t)

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -11,6 +11,9 @@
 #ifndef _stereo_reconstructor_msgs_h
 #define _stereo_reconstructor_msgs_h
 
+#include "cfe_sb.h"
+#include "moonranger_common_types.h"
+
 /*************************************************************************/
 /*** STEREO App command codes*/
 #define STEREO_NOOP_CC 0

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -36,6 +36,8 @@ typedef STEREO_NoArgsCmd_t STEREO_ResetCounters_t;
 typedef STEREO_NoArgsCmd_t STEREO_Process_t;
 typedef STEREO_NoArgsCmd_t STEREO_Receive_Camera_Calib_t;
 
+#define STEREO_CMD_TLM_LNGTH sizeof(STEREO_NoArgsCmd_t)
+
 /*************************************************************************/ 
 /** Type definition (STEREO App housekeeping)*/
 
@@ -57,6 +59,8 @@ typedef struct
 {
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendPclMsgTlm_t;
+
+#define STEREO_SEND_PCL_TLM_LNGTH sizeof(STEREO_SendPclMsgTlm_t)
 
 /*
  * Buffer to hold telemetry data prior to sending

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -38,11 +38,11 @@ typedef STEREO_NoArgsCmd_t STEREO_Receive_Camera_Calib_t;
 
 #define STEREO_CMD_TLM_LNGTH sizeof(STEREO_NoArgsCmd_t)
 
-/*************************************************************************/ 
+/*************************************************************************/
 /** Type definition (STEREO App housekeeping)*/
 
-#define STEREO_HK_PAYLOAD_LEN               sizeof(STEREO_HkTlm_Payload_t)
-#define STEREO_HK_TLM_LEN                   sizeof(STEREO_HkTlm_t)
+#define STEREO_HK_PAYLOAD_LEN sizeof(STEREO_HkTlm_Payload_t)
+#define STEREO_HK_TLM_LEN sizeof(STEREO_HkTlm_t)
 
 typedef struct {
     uint8 CommandErrorCounter;
@@ -55,16 +55,14 @@ typedef struct {
     STEREO_HkTlm_Payload_t Payload;
 } OS_PACK STEREO_HkTlm_t;
 
-typedef struct
-{
-  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendPclMsgTlm_t;
 
 #define STEREO_SEND_PCL_TLM_LNGTH sizeof(STEREO_SendPclMsgTlm_t)
 
-typedef struct
-{
-  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendDispMsgTlm_t;
 
 /*

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -58,13 +58,6 @@ typedef struct {
 typedef struct
 {
   uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
-} OS_PACK STEREO_SendHkTlm_t;
-
-#define STEREO_SEND_HK_TLM_LNGTH sizeof(STEREO_SendHkTlm_t)
-
-typedef struct
-{
-  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendPclMsgTlm_t;
 
 #define STEREO_SEND_PCL_TLM_LNGTH sizeof(STEREO_SendPclMsgTlm_t)

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -14,6 +14,7 @@
 #include "rover_init_msg.h"
 #include "sunsensor_msg.h"
 #include "nss_if_msp_msgs.h"
+#include "stereo_reconstructor_msgs.h"
 
 #define SUCCESS 1
 #define FAILURE 0
@@ -48,6 +49,7 @@ typedef union {
     SunSensorTlm_Tlm_t sunsensor_tlm;
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
+    STEREO_HkTlm_t StereoHk_Tlm;
 } message_builder_u;
 
 int messageExtract(void* MsgPtr, int msg_len_bytes,

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,6 +50,12 @@ typedef union {
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
     STEREO_HkTlm_t StereoHk_Tlm;
+    STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
+    STEREO_Noop_t StereoNoOp_Tlm;
+    STEREO_ResetCounters_t StereoResetCounters_Tlm;
+    STEREO_Process_t StereoProcess_Tlm;
+    STEREO_Receive_Camera_Calib_t StereoReceiveCameraCalib_Tlm;
+
 } message_builder_u;
 
 int messageExtract(void* MsgPtr, int msg_len_bytes,

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,12 +50,12 @@ typedef union {
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
     STEREO_HkTlm_t StereoHk_Tlm;
-    STEREO_SendHkTlm_t StereoSendHk_Tlm;
     STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
     STEREO_Noop_t StereoNoOp_Tlm;
     STEREO_ResetCounters_t StereoResetCounters_Tlm;
     STEREO_Process_t StereoProcess_Tlm;
     STEREO_Receive_Camera_Calib_t StereoReceiveCameraCalib_Tlm;
+    STEREO_NoArgsCmd_t StereoNoArgs_Tlm;
 
 } message_builder_u;
 

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -1,21 +1,21 @@
 #ifndef _message_builder_h
 #define _message_builder_h
+#include "battery_enable_msg.h"
 #include "ccsds.h"
 #include "cfe_sb.h"
 #include "common_types.h"
 #include "goal_msg.h"
-#include "moonranger_msgids.h"
-#include "pose_msg.h"
-#include "pose_estimator_msgs.h"
-#include "teleop_msg.h"
-#include "battery_enable_msg.h"
-#include "wheel_velocity_command_msg.h"
 #include "heater_control_msp_msgs.h"
+#include "moonranger_msgids.h"
+#include "nss_if_msp_msgs.h"
+#include "pose_estimator_msgs.h"
+#include "pose_msg.h"
 #include "power_switching_msp_msgs.h"
 #include "rover_init_msg.h"
-#include "sunsensor_msg.h"
-#include "nss_if_msp_msgs.h"
 #include "stereo_reconstructor_msgs.h"
+#include "sunsensor_msg.h"
+#include "teleop_msg.h"
+#include "wheel_velocity_command_msg.h"
 
 #define SUCCESS 1
 #define FAILURE 0
@@ -65,7 +65,7 @@ int messageExtract(void* MsgPtr, int msg_len_bytes,
                    message_builder_u* msg_container);
 
 int messageBuildGeneric(void* dataPtr, message_builder_u* msg_container,
-                 int data_len_bytes, int32 msgId, int header_length);
+                        int data_len_bytes, int32 msgId, int header_length);
 int messageBuild(void* dataPtr, message_builder_u* msg_container,
                  int data_len_bytes, int32 msgId);
 

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,6 +50,7 @@ typedef union {
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
     STEREO_HkTlm_t StereoHk_Tlm;
+    STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
     STEREO_Noop_t StereoNoOp_Tlm;
     STEREO_ResetCounters_t StereoResetCounters_Tlm;
     STEREO_Process_t StereoProcess_Tlm;

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,6 +50,7 @@ typedef union {
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
     STEREO_HkTlm_t StereoHk_Tlm;
+    STEREO_SendHkTlm_t StereoSendHk_Tlm;
     STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
     STEREO_Noop_t StereoNoOp_Tlm;
     STEREO_ResetCounters_t StereoResetCounters_Tlm;

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -62,6 +62,8 @@ typedef union {
 int messageExtract(void* MsgPtr, int msg_len_bytes,
                    message_builder_u* msg_container);
 
+int messageBuildGeneric(void* dataPtr, message_builder_u* msg_container,
+                 int data_len_bytes, int32 msgId, int header_length);
 int messageBuild(void* dataPtr, message_builder_u* msg_container,
                  int data_len_bytes, int32 msgId);
 

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,7 +50,6 @@ typedef union {
     NSS_HealthMsg_Tlm_t NSSHealthMsg_Tlm;
     NSS_SetParams_Tlm_t NSSSetParams_Tlm;
     STEREO_HkTlm_t StereoHk_Tlm;
-    STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
     STEREO_Noop_t StereoNoOp_Tlm;
     STEREO_ResetCounters_t StereoResetCounters_Tlm;
     STEREO_Process_t StereoProcess_Tlm;

--- a/message-utilities/src/message_builder.c
+++ b/message-utilities/src/message_builder.c
@@ -36,11 +36,9 @@ int messageExtract(void *MsgPtr,int msg_len_bytes, message_builder_u* msg_contai
   return SUCCESS;
 }
 
-
-int messageBuild(void* dataPtr, message_builder_u* msg_container,int data_len_bytes, int32 msgId)
+// generic message builder
+int messageBuildGeneric(void* dataPtr, message_builder_u* msg_container,int data_len_bytes, int32 msgId, int header_length)
 {
-
-  int header_length = CFE_SB_TLM_HDR_SIZE;
   // Fill the header
   CFE_SB_InitMsg(&msg_container->msg_buf_ptr, (CFE_SB_MsgId_t)msgId, header_length+ data_len_bytes, true);
 
@@ -58,3 +56,10 @@ int messageBuild(void* dataPtr, message_builder_u* msg_container,int data_len_by
 
 }
 
+// builds message with TLM header of length CFE_SB_TLM_HDR_SIZE
+int messageBuild(void* dataPtr, message_builder_u* msg_container,int data_len_bytes, int32 msgId)
+{
+  int header_length = CFE_SB_TLM_HDR_SIZE;
+
+  return messageBuildGeneric(dataPtr, msg_container, data_len_bytes, msgId, header_length);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update stereo message definitions.

## Description
<!--- Describe your changes in detail -->
- Update stereo message definitions.
- Add a genericMessageBuild function to handle messages which use a command header `uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE]`.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Tested by corresponding tests on the MCS backend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
