### PR TITLE
Fixing bugs found during compiling and static checks of rover messages

### DIFF
--- a/fsw/public_inc/master_comms_bus_protocol.h
+++ b/fsw/public_inc/master_comms_bus_protocol.h
@@ -63,6 +63,8 @@ typedef struct {
     uint8_t __padding;                  // ensures 16 bit alignment
 } main_bus_hdr_t;
 
+#define MAIN_BUS_HDR_LEN sizeof(main_bus_hdr_t)
+
 typedef struct {
     int16_t reboot_counter;        // the number of times MSP has rebooted
     int16_t invalid_msg_counter;   // the number of times an MSP has received

--- a/fsw/public_inc/motor_control_msgs.h
+++ b/fsw/public_inc/motor_control_msgs.h
@@ -76,7 +76,7 @@ typedef struct {
 typedef struct {
     pid_gains_t motor_pid_gains;
     motor_id_t motor_id;
-    uint8_t __padding;
+    uint8_t __padding[3];
 } set_motor_pid_payload_t;
 
 #define SET_MOTOR_PID_PAYLOAD_LEN sizeof(set_motor_pid_payload_t)

--- a/fsw/public_inc/nss_msgs.h
+++ b/fsw/public_inc/nss_msgs.h
@@ -19,6 +19,8 @@
 #include "master_comms_bus_protocol.h"
 #include "moonranger_common_types.h"
 
+#define NSS_DATA_LEN 89
+
 /**************************************************************************
  * MOONRANGER MESSAGE PAYLOADS
  **************************************************************************/
@@ -39,7 +41,7 @@ typedef struct {
 
 // NSS telemetry message
 typedef struct {
-    uint8_t nss_data[89];   // data from sensor
+    uint8_t nss_data[NSS_DATA_LEN];   // data from sensor
     uint8_t status;   // status byte: bit 0 = no telemetry, TODO: add more flags
                       // here
     msp_health_payload_t msp_health;

--- a/fsw/public_inc/sunsensor_msgs.h
+++ b/fsw/public_inc/sunsensor_msgs.h
@@ -50,7 +50,7 @@ typedef struct {
     msp_health_payload_t msp_health;
 } sunsensor_telem_payload_t;
 
-#define SUNSENSOR_TELEM_PAYLOAD_LEN sizeof(sunsensor_telem_payload_t);
+#define SUNSENSOR_TELEM_PAYLOAD_LEN sizeof(sunsensor_telem_payload_t)
 
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
@@ -62,7 +62,7 @@ typedef struct {
     uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
 } get_sunsensor_data_cmd_t;
 
-#define GET_SUNSENSOR_DATA_CMD_LEN sizeof(get_sunsensor_data_cmd_t);
+#define GET_SUNSENSOR_DATA_CMD_LEN sizeof(get_sunsensor_data_cmd_t)
 
 // sun sensor telem message
 typedef struct {
@@ -72,6 +72,6 @@ typedef struct {
     uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
 } sunsensor_telem_msg_t;
 
-#define GET_SUNSENSOR_TELEM_LEN sizeof(sunsensor_telem_msg_t);
+#define GET_SUNSENSOR_TELEM_LEN sizeof(sunsensor_telem_msg_t)
 
 #endif /* _sunsensor_msgs_h */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Update several bugs and missing define in rover messages found during testing.
1 - missing explicit padding on one struct
2 - missing data length 
3 - magic number replaced with define
4 - semi colons on define statements,

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Compiled successfully on ubuntu machine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
