### PR TITLE
changed timestamp of imu_data msg from StsTime to OS_time

### DIFF
--- a/fsw/public_inc/imu_data_msg.h
+++ b/fsw/public_inc/imu_data_msg.h
@@ -1,18 +1,18 @@
 /****************************************************************
- * 
+ *
  * @file 		imu_data_msg.h
- * 
+ *
  * @brief 		The message definitions for the IMU data
- * 
+ *
  * @version 	1.0
  * @date 		12/06/2021
- * 
+ *
  * @authors 	Ben Kolligs, ...
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
- * 
- * @note		This file only contains app specific command and 
+ *
+ * @note		This file only contains app specific command and
  * 				telemetry message definitions and command codes.
- * 
+ *
  ****************************************************************/
 #ifndef _imu_data_msg_h_
 #define _imu_data_msg_h_
@@ -25,27 +25,27 @@ typedef float float32;
  * This data structure is inspired by the ROS sensor_msgs/Imu.msg file
  */
 typedef struct {
-    CFE_TIME_SysTime_t timeStamp;
-	/* The orientation of the rover is given by a quaternion */
+    OS_time_t timeStamp;
+    /* The orientation of the rover is given by a quaternion */
     float32 orientation_x;
     float32 orientation_y;
     float32 orientation_z;
     float32 orientation_w;
     float32 orientation_covariance[9];
 
-	/* Angular velocity is in rad/s */
+    /* Angular velocity is in rad/s */
     float32 angular_velocity_x;
     float32 angular_velocity_y;
     float32 angular_velocity_z;
     float32 angular_velocity_covariance[9];
 
-	/* Linear acceleration is given in m/s^2 */
+    /* Linear acceleration is given in m/s^2 */
     float32 linear_acceleration_x;
     float32 linear_acceleration_y;
     float32 linear_acceleration_z;
     float32 linear_acceleration_covariance[9];
 
-	/* Inclinometer is given in m/s^2 */
+    /* Inclinometer is given in m/s^2 */
     float32 inclinometer_x;
     float32 inclinometer_y;
     float32 inclinometer_z;
@@ -53,22 +53,20 @@ typedef struct {
 } MOONRANGER_IMUData_t;
 
 /* Type definition for the IMU Data telemetry */
-typedef struct
-{
-	uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
-	MOONRANGER_IMUData_t data;
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    MOONRANGER_IMUData_t data;
 } OS_PACK MOONRANGER_IMUData_Tlm_t;
 
 /**
  * Buffer to hold the IMU Data packet prior to publishing on the software bus
  */
-typedef union 
-{
-	CFE_SB_Msg_t MsgHdr;
-	MOONRANGER_IMUData_Tlm_t IMUTlm;
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    MOONRANGER_IMUData_Tlm_t IMUTlm;
 } MOONRANGER_IMUDataBuffer_t;
 
 /* Message sizes */
 #define MOONRANGER_IMU_DATA_LNGTH sizeof(MOONRANGER_IMUData_t)
 #define MOONRANGER_IMU_DATA_TLM_LNGTH sizeof(MOONRANGER_IMUData_Tlm_t)
-#endif //_imu_data_msg_h_ header
+#endif   //_imu_data_msg_h_ header

--- a/fsw/public_inc/imu_data_msg.h
+++ b/fsw/public_inc/imu_data_msg.h
@@ -25,7 +25,16 @@ typedef float float32;
  * This data structure is inspired by the ROS sensor_msgs/Imu.msg file
  */
 typedef struct {
+    /**
+     * The type of the timeStamp is "OS_time_t" because it is set using the
+     * return value of the "CFE_PSP_GetTime()" function. If I were to use the
+     * "CFE_TIME_GetTime()" function to set the timestamp instead, then the type
+     * of the timestamp would have to be "CFE_TIME_SysTime_t". I use
+     * "CFE_PSP_GetTime()" because it guarantees monotonic timestamps whereas
+     * "CFE_TIME_GetTime()" does not
+     */
     OS_time_t timeStamp;
+
     /* The orientation of the rover is given by a quaternion */
     float32 orientation_x;
     float32 orientation_y;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed type of timestamp field in imu_data msg struct

## Description
<!--- Describe your changes in detail -->

## 
<!--- Why is this change required? What problem does it solve? -->
OS_time is the return type of the new function we are using to get the time (PSP_gettime). We are usign that new functoin instead of the regular cfe_gettime because the later is not guarenteed to be monotonic while the psp one is.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
