### PR TITLE
Changed the speed of incoming wheels to be RPM instead of rad/s. This…

### DIFF
--- a/fsw/public_inc/wheel_velocity_current_msg.h
+++ b/fsw/public_inc/wheel_velocity_current_msg.h
@@ -22,10 +22,10 @@ typedef float float32;
 /* The Incoming wheel velocity packet */
 typedef struct {
     CFE_TIME_SysTime_t timeStamp;
-    float32 leftFront;    // rad/s
-    float32 rightFront;   // rad/s
-    float32 leftBack;     // rad/s
-    float32 rightBack;    // rad/s
+    float32 leftFront;    // RPM
+    float32 rightFront;   // RPM
+    float32 leftBack;     // RPM
+    float32 rightBack;    // RPM
 } MOONRANGER_WheelVelocityCurrent_t;
 
 /* Type definition for wheel velocity telemetry */


### PR DESCRIPTION
… conversion will take place in the vehicle controller

<!--- Provide a general summary of your changes in the Title above -->

## Description
Just changed a comment. The implication of this PR is that the wheel velocity should be sent from the peripheral computer in units of revolutions per minute. The vehicle controller will assume this and convert to rad/s, which it needs to calculate the kinematics properly. 
