### PR TITLE
Add battery and wifi enable commands to message builder

### DIFF
--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -60,6 +60,8 @@ typedef union {
     IMU_DRIVER_HkTlm_t Imu_driver_Tlm;
     MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;
     OBC_Peripheral_Sensor_Tlm_t PeripheralSensor_Tlm;
+    OBC_BatteryEnable_Cmd_t BatteryEnable_Tlm;
+    OBC_WifiEnable_Cmd_t WifiEnable_Tlm;
 } message_builder_u;
 
 int messageExtract(void* MsgPtr, int msg_len_bytes,

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -13,6 +13,7 @@
 #include "wheel_velocity_command_msg.h"
 #include "imu_driver_msgs.h"
 #include "obc_msgs.h"
+#include "drive_arc_msg.h"
 #define SUCCESS 1
 #define FAILURE 0
 
@@ -57,6 +58,7 @@ typedef union {
     STEREO_Receive_Camera_Calib_t StereoReceiveCameraCalib_Tlm;
     STEREO_NoArgsCmd_t StereoNoArgs_Tlm;
     IMU_DRIVER_HkTlm_t Imu_driver_Tlm;
+    MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;
     OBC_Peripheral_Sensor_Tlm_t PeripheralSensor_Tlm;
 } message_builder_u;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add battery and wifi enable commands to message builder.  
Needed to send these commands from MCS to the rover.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #80 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Tested on the MCS backend repo.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
