### PR TITLE
Add tlm output messages

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -122,7 +122,6 @@
  * @note Telemetry message IDs in this section should fit within
  * 0x0AC0-0x0AFF inclusive.
  */
-#define OBC_SET_WHEEL_SPEED_CMD_MID 0x1AC0         // single wheel speed
 #define OBC_SET_WHEEL_SPEED_ALL_CMD_MID 0x1AC1     // set all wheel speeds
 #define OBC_SET_MOTOR_PID_CMD_MID 0x1AC2           // set the pid values
 #define OBC_SET_SOLAR_PANEL_STATE_CMD_MID 0x1AC3   // set panel up or down

--- a/fsw/public_inc/motor_control_msgs.h
+++ b/fsw/public_inc/motor_control_msgs.h
@@ -70,8 +70,6 @@ typedef struct {
     int16_t motor4_speed;
 } set_wheel_speed_all_payload_t;
 
-#define SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(set_wheel_speed_all_payload_t)
-
 // set motor PID command
 typedef struct {
     pid_gains_t motor_pid_gains;

--- a/fsw/public_inc/motor_control_msgs.h
+++ b/fsw/public_inc/motor_control_msgs.h
@@ -70,6 +70,8 @@ typedef struct {
     int16_t motor4_speed;
 } set_wheel_speed_all_payload_t;
 
+#define SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(set_wheel_speed_all_payload_t)
+
 // set motor PID command
 typedef struct {
     pid_gains_t motor_pid_gains;

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -101,6 +101,8 @@ typedef struct {
     uint32_t duration;   // seconds
 } Set_Wheel_Speed_All_Cmd_Payload;
 
+#define SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(Set_Wheel_Speed_All_Cmd_Payload)
+
 // cFS command structure
 typedef struct {
     uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
@@ -139,7 +141,7 @@ typedef union {
 // cFS command structure
 typedef struct {
     uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
-    set_motor_pid_payload_t payload;
+    set_solar_panel_state_payload_t payload;
 } OS_PACK OBC_Set_Solar_Panel_State_Cmd_t;
 
 /**

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -101,7 +101,7 @@ typedef struct {
     uint32_t duration;   // seconds
 } Set_Wheel_Speed_All_Cmd_Payload;
 
-#define SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(Set_Wheel_Speed_All_Cmd_Payload)
+#define OBC_SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(Set_Wheel_Speed_All_Cmd_Payload)
 
 // cFS command structure
 typedef struct {

--- a/fsw/public_inc/tlm_output_msgs.h
+++ b/fsw/public_inc/tlm_output_msgs.h
@@ -20,6 +20,9 @@
 #ifndef _tlm_output_msg_h_
 #define _tlm_output_msg_h_
 
+#include "cfe_sb.h"
+#include "moonranger_common_types.h"
+
 #define TO_NOP_CC             0 /*  no-op command     */
 #define TO_RESET_STATUS_CC    1 /*  reset status      */
 #define TO_ADD_PKT_CC         2 /*  add packet        */

--- a/fsw/public_inc/tlm_output_msgs.h
+++ b/fsw/public_inc/tlm_output_msgs.h
@@ -101,6 +101,8 @@ typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_ResetCounters_t;
 typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_RemoveAll_t;
 typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_SendDataTypes_t;
 
+#define TLM_OUTPUT_CMD_TLM_LNGTH sizeof(TLM_OUTPUT_NoArgsCmd_t)
+
 typedef struct
 {
     CFE_SB_MsgId_t Stream;

--- a/fsw/public_inc/tlm_output_msgs.h
+++ b/fsw/public_inc/tlm_output_msgs.h
@@ -101,7 +101,7 @@ typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_ResetCounters_t;
 typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_RemoveAll_t;
 typedef TLM_OUTPUT_NoArgsCmd_t TLM_OUTPUT_SendDataTypes_t;
 
-#define TLM_OUTPUT_CMD_TLM_LNGTH sizeof(TLM_OUTPUT_NoArgsCmd_t)
+#define TLM_OUTPUT_CMD_LEN sizeof(TLM_OUTPUT_NoArgsCmd_t)
 
 typedef struct
 {
@@ -116,6 +116,9 @@ typedef struct
     uint8                      CmdHeader[CFE_SB_CMD_HDR_SIZE];
     TLM_OUTPUT_AddPacket_Payload_t Payload;
 } TLM_OUTPUT_AddPacket_t;
+
+#define TLM_OUTPUT_ADD_PACKET_PAYLOAD_LEN sizeof(TLM_OUTPUT_AddPacket_Payload_t)
+#define TLM_OUTPUT_ADD_PACKET_CMD_LEN sizeof(TLM_OUTPUT_AddPacket_t)
 
 /*****************************************************************************/
 
@@ -139,6 +142,9 @@ typedef struct
     TLM_OUTPUT_RemovePacket_Payload_t Payload;
 } TLM_OUTPUT_RemovePacket_t;
 
+#define TLM_OUTPUT_REMOVE_PACKET_PAYLOAD_LEN sizeof(TLM_OUTPUT_RemovePacket_Payload_t)
+#define TLM_OUTPUT_REMOVE_PACKET_CMD_LEN sizeof(TLM_OUTPUT_RemovePacket_t)
+
 /******************************************************************************/
 
 typedef struct
@@ -151,6 +157,9 @@ typedef struct
     uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
     TLM_OUTPUT_EnableOutput_Payload_t Payload;
 } TLM_OUTPUT_EnableOutput_t;
+
+#define TLM_OUTPUT_ENABLE_OUTPUT_PAYLOAD_LEN sizeof(TLM_OUTPUT_EnableOutput_Payload_t)
+#define TLM_OUTPUT_ENABLE_OUTPUT_CMD_LEN sizeof(TLM_OUTPUT_EnableOutput_t)
 
 typedef union
 {

--- a/fsw/public_inc/tlm_output_msgs.h
+++ b/fsw/public_inc/tlm_output_msgs.h
@@ -47,7 +47,8 @@ typedef struct
     TLM_OUTPUT_HkTlm_Payload_t Payload;
 } TLM_OUTPUT_HkTlm_t;
 
-#define TO_HK_TLM_LNGTH sizeof(TLM_OUTPUT_HkTlm_t)
+#define TLM_OUTPUT_HK_PAYLOAD_LEN sizeof(TLM_OUTPUT_HkTlm_Payload_t)
+#define TLM_OUTPUT_HK_TLM_LEN sizeof(TLM_OUTPUT_HkTlm_t)
 
 /******************************************************************************/
 
@@ -79,7 +80,8 @@ typedef struct
     TLM_OUTPUT_DataTypes_Payload_t Payload;
 } TLM_OUTPUT_DataTypes_t;
 
-#define TO_DATA_TYPES_LNGTH sizeof(TLM_OUTPUT_DataTypes_t)
+#define TLM_OUTPUT_DATA_TYPES_PAYLOAD_LEN sizeof(TLM_OUTPUT_DataTypes_Payload_t)
+#define TLM_OUTPUT_DATA_TYPES_TLM_LEN sizeof(TLM_OUTPUT_DataTypes_t)
 
 /******************************************************************************/
 

--- a/message-utilities/cfe_components/cfe_error.h
+++ b/message-utilities/cfe_components/cfe_error.h
@@ -1,0 +1,1527 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+**  Filename: cfe_error.h
+**
+**  Title:    cFE Status Code Definition Header File
+**
+**  Purpose:
+**            Common source of cFE API return status codes.
+**
+**  Design Notes:
+**
+**  References:
+**     Flight Software Branch C Coding Standard Version 1.0a
+**
+**/
+
+/*
+** Ensure that header is included only once...
+*/
+#ifndef _cfe_error_
+#define _cfe_error_
+
+/* Include Files */
+// #include "osapi.h"
+
+/*
+**  Status Codes are 32 bit values formatted as follows:
+**
+**   3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
+**   1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+**  +---+---+-----+-----------------+-------------------------------+
+**  |Sev| R | Srv | Mission Defined |               Code            |
+**  +---+---+-----+-----------------+-------------------------------+
+**
+**  where
+**
+**      Sev - is the severity code
+**
+**          00 - Success
+**          01 - Informational
+**          11 - Error
+**
+**      R - are reserved bits
+**
+**      Srv - is the cFE Service Identifier
+**
+**          000 - Not a cFE Service
+**          001 - Events Services
+**          010 - Executive Services
+**          011 - File Services
+**          100 - Generic code for all services
+**          101 - Software Bus Services
+**          110 - Tables Services
+**          111 - Time Services
+**
+**
+**      Mission Defined - These bits are available for Mission
+**                        specific coding standards.  They can
+**                        be used to classify error codes related
+**                        to mission specific library function calls, etc.
+**
+**      Code - is the status code
+*/
+
+
+/*
+** Error Severity
+*/
+#define CFE_SEVERITY_BITMASK     ((int32)0xc0000000)  /**< @brief Error Severity Bitmask */
+
+#define CFE_SEVERITY_SUCCESS     ((int32)0x00000000)  /**< @brief Severity Success */
+#define CFE_SEVERITY_INFO        ((int32)0x40000000)  /**< @brief Severity Info */
+#define CFE_SEVERITY_ERROR       ((int32)0xc0000000)  /**< @brief Severity Error */
+
+/*
+** cFE Service Identifiers
+*/
+#define CFE_SERVICE_BITMASK      ((int32)0x0e000000)  /**< @brief Error Service Bitmask */
+
+#define CFE_EVENTS_SERVICE       ((int32)0x02000000)  /**< @brief Event Service */
+#define CFE_EXECUTIVE_SERVICE    ((int32)0x04000000)  /**< @brief Executive Service */
+#define CFE_FILE_SERVICE         ((int32)0x06000000)  /**< @brief File Service */
+#define CFE_GENERIC_SERVICE      ((int32)0x08000000)  /**< @brief Generic Service */
+#define CFE_SOFTWARE_BUS_SERVICE ((int32)0x0a000000)  /**< @brief Software Bus Service */
+#define CFE_TABLE_SERVICE        ((int32)0x0c000000)  /**< @brief Table Service */
+#define CFE_TIME_SERVICE         ((int32)0x0e000000)  /**< @brief Time Service */
+
+/*
+************* COMMON STATUS CODES *************
+*/
+
+/** @defgroup CFEReturnCodes cFE Return Code Defines
+ * @{
+ */
+
+/**
+ * @brief Sucessful execution
+ *
+ *  Operation was performed successfully
+ */
+#define CFE_SUCCESS              (0)
+
+/**
+ * @brief No Counter Increment
+ *
+ *  Informational code indicating that a command was processed
+ *  successfully but that the command counter should _not_ be incremented.
+ */
+#define CFE_STATUS_NO_COUNTER_INCREMENT     ((int32)0x48000001)
+
+/**
+ * @brief Wrong Message Length
+ *
+ *  This error code will be returned when a message validation process
+ *  determined that the message length is incorrect
+ *
+ */
+#define CFE_STATUS_WRONG_MSG_LENGTH         ((int32)0xc8000002)
+
+/**
+ * @brief Unknown Message ID
+ *
+ *  This error code will be returned when a message identification process
+ *  determined that the message ID does not correspond to a known value
+ *
+ */
+#define CFE_STATUS_UNKNOWN_MSG_ID           ((int32)0xc8000003)
+
+/**
+ * @brief Bad Command Code
+ *
+ *  This error code will be returned when a message identification process
+ *  determined that the command code is does not correspond to any known value
+ *
+ */
+#define CFE_STATUS_BAD_COMMAND_CODE         ((int32)0xc8000004)
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_STATUS_NOT_IMPLEMENTED          ((int32)0xc800ffff)
+
+
+
+
+/*
+************* EVENTS SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Unknown Filter
+ *
+ *  #CFE_EVS_Register FilterScheme parameter was illegal
+ *
+ */
+#define CFE_EVS_UNKNOWN_FILTER            ((int32)0xc2000001)
+
+/**
+ * @brief Application Not Registered
+ *
+ *  Calling application never previously called #CFE_EVS_Register
+ *
+ */
+#define CFE_EVS_APP_NOT_REGISTERED        ((int32)0xc2000002)
+
+/**
+ * @brief Illegal Application ID
+ *
+ *  Application ID returned by #CFE_ES_GetAppIDByName is greater
+ *  than #CFE_PLATFORM_ES_MAX_APPLICATIONS
+ *
+ */
+#define CFE_EVS_APP_ILLEGAL_APP_ID        ((int32)0xc2000003)
+
+/**
+ * @brief Application Filter Overload
+ *
+ *  Number of Application event filters input upon
+ *  registration is greater than #CFE_PLATFORM_EVS_MAX_EVENT_FILTERS
+ *
+ */
+#define CFE_EVS_APP_FILTER_OVERLOAD        ((int32)0xc2000004)
+
+/**
+ * @brief Reset Area Pointer Failure
+ *
+ *  Could not get pointer to the ES Reset area, so we could
+ *  not get the pointer to the EVS Log.
+ *
+ */
+#define CFE_EVS_RESET_AREA_POINTER        ((int32)0xc2000005)
+
+
+/**
+ * @brief Event Not Registered
+ *
+ *  #CFE_EVS_ResetFilter EventID argument was not found in
+ *  any event filter registered by the calling application.
+ *
+ */
+#define CFE_EVS_EVT_NOT_REGISTERED        ((int32)0xc2000006)
+
+/**
+ * @brief File Write Error
+ *
+ *  A file write error occurred while processing an EVS command
+ *
+ */
+#define CFE_EVS_FILE_WRITE_ERROR          ((int32)0xc2000007)
+
+/**
+ * @brief Invalid Pointer
+ *
+ *  Invalid parameter supplied to EVS command
+ *
+ */
+#define CFE_EVS_INVALID_PARAMETER         ((int32)0xc2000008)
+
+/**
+ * @brief Function Disabled
+ *
+ *  EVS command sent that requires a feature currently turned off
+ *  This is to differentiate between "NOT_IMPLEMENTED" where the
+ *  feature IS implemented but it is disabled at runtime.
+ */
+#define CFE_EVS_FUNCTION_DISABLED         ((int32)0xc2000009)
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_EVS_NOT_IMPLEMENTED ((int32)0xc200ffff)
+
+/*
+************* EXECUTIVE SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Application ID Error
+ *
+ *  The given application ID does not reflect a currently active application.
+ *
+ */
+#define CFE_ES_ERR_APPID     ((int32)0xc4000001)
+
+/**
+ * @brief Application Name Error
+ *
+ *  There is no match for the given application name in the current application list.
+ *
+ */
+#define CFE_ES_ERR_APPNAME   ((int32)0xc4000002)
+
+/**
+ * @brief Invalid Pointer
+ *
+ *  Invalid pointer argument (NULL)
+ *
+ */
+#define CFE_ES_ERR_BUFFER    ((int32)0xc4000003)
+
+/**
+ * @brief Application Create Error
+ *
+ *  There was an error loading or creating the App.
+ *
+ */
+#define CFE_ES_ERR_APP_CREATE  ((int32)0xc4000004)
+
+/**
+ * @brief Child Task Create Error
+ *
+ *  There was an error creating a child task.
+ *
+ */
+#define CFE_ES_ERR_CHILD_TASK_CREATE  ((int32)0xc4000005)
+
+/**
+ * @brief System Log Full
+ *
+ *  The cFE system Log is full.
+ *  This error means the message was not logged at all
+ *
+ */
+#define CFE_ES_ERR_SYS_LOG_FULL  ((int32)0xc4000006)
+
+/**
+ * @brief Memory Handle Error
+ *
+ *  The Memory Pool handle is invalid.
+ *
+ */
+#define CFE_ES_ERR_MEM_HANDLE  ((int32)0xc4000007)
+
+/**
+ * @brief Memory Block Size Error
+ *
+ *  The block size requested is invalid.
+ *
+ */
+#define CFE_ES_ERR_MEM_BLOCK_SIZE  ((int32)0xc4000008)
+
+/**
+ * @brief Load Library Error
+ *
+ *  Could not load the shared library.
+ *
+ */
+#define CFE_ES_ERR_LOAD_LIB  ((int32)0xc4000009)
+
+/**
+ * @brief Bad Argument
+ *
+ *  Bad parameter passed into an ES API.
+ *
+ */
+#define CFE_ES_BAD_ARGUMENT  ((int32)0xc400000a)
+
+/** 
+ * @brief Child Task Register Error
+ *
+ *  Errors occured when trying to register a child task.
+ *
+ */
+#define CFE_ES_ERR_CHILD_TASK_REGISTER  ((int32)0xc400000b)
+
+/** 
+ * @brief Shell Command Error
+ *
+ *  Error occured ehen trying to pass a system call to the OS shell
+ *
+ */
+#define CFE_ES_ERR_SHELL_CMD  ((int32)0xc400000c)
+
+/**
+ * @brief CDS Already Exists
+ *
+ *  The Application is receiving the pointer to a CDS that was already present.
+ *
+ */
+#define CFE_ES_CDS_ALREADY_EXISTS  ((int32)0x4400000d)
+
+
+/**
+ * @brief CDS Insufficient Memory
+ *
+ *  The Application is requesting a CDS Block that is larger than the remaining
+ *  CDS memory.
+ *
+ */
+#define CFE_ES_CDS_INSUFFICIENT_MEMORY  ((int32)0xc400000e)
+
+
+/**
+ * @brief CDS Invalid Name
+ *
+ *  The Application is requesting a CDS Block with an invalid ASCII string name.
+ *  Either the name is too long (> #CFE_MISSION_ES_CDS_MAX_NAME_LENGTH) or was an empty string.
+ *
+ */
+#define CFE_ES_CDS_INVALID_NAME  ((int32)0xc400000f)
+
+
+/**
+ * @brief CDS Invalid Size
+ *
+ *  The Application is requesting a CDS Block with a size of zero.
+ *
+ */
+#define CFE_ES_CDS_INVALID_SIZE  ((int32)0xc4000010)
+
+
+/**
+ * @brief CDS Registry Full
+ *
+ *  The CDS Registry has as many entries in it as it can hold.  The
+ *  CDS Registry size can be adjusted with the #CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES
+ *  macro defined in the cfe_platform_cfg.h file.
+ *
+ */
+#define CFE_ES_CDS_REGISTRY_FULL  ((int32)0xc4000011)
+
+
+/**
+ * @brief CDS Invalid
+ *
+ *  The CDS contents are invalid.
+ *
+ */
+#define CFE_ES_CDS_INVALID  ((int32)0xc4000012)
+
+
+/**
+ * @brief CDS Access Error
+ *
+ *  The CDS was inaccessible
+ *
+ */
+#define CFE_ES_CDS_ACCESS_ERROR  ((int32)0xc4000013)
+
+
+/**
+ * @brief File IO Error
+ *
+ *  Occurs when a file operation fails
+ *
+ */
+#define CFE_ES_FILE_IO_ERR  ((int32)0xc4000014)
+
+
+/**
+ * @brief Reset Area Access Error
+ *
+ *  Occurs when the BSP is not successful in returning the reset area address.
+ *
+ */
+#define CFE_ES_RST_ACCESS_ERR  ((int32)0xc4000015)
+
+/**
+ * @brief Task ID Error
+ *
+ *  Occurs when the Task ID passed into #CFE_ES_GetTaskInfo is invalid.
+ *
+ */
+#define CFE_ES_ERR_TASKID  ((int32)0xc4000016)
+
+/**
+ * @brief Application Register Error
+ *
+ *  Occurs when the #CFE_ES_RegisterApp fails.
+ *
+ */
+#define CFE_ES_ERR_APP_REGISTER  ((int32)0xc4000017)
+
+/**
+ * @brief Child Task Delete Error
+ *
+ *  There was an error deleting a child task.
+ *
+ */
+#define CFE_ES_ERR_CHILD_TASK_DELETE  ((int32)0xc4000018)
+
+/**
+ * @brief Child Task Delete Passed Main Task
+ *
+ *  There was an attempt to delete a cFE App Main Task with
+ *  the #CFE_ES_DeleteChildTask API.
+ *
+ */
+#define CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK  ((int32)0xc4000019)
+
+/**
+ * @brief CDS Block CRC Error
+ *
+ *  Occurs when trying to read a CDS Data block and the CRC of the current
+ *  data does not match the stored CRC for the data.  Either the contents of
+ *  the CDS Data Block are corrupted or the CDS Control Block is corrupted.
+ *
+ */
+#define CFE_ES_CDS_BLOCK_CRC_ERR  ((int32)0xc400001A)
+
+/**
+ * @brief Mutex Semaphore Delete Error
+ *
+ *  Occurs when trying to delete a Mutex that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_MUT_SEM_DELETE_ERR  ((int32)0xc400001B)
+
+
+/**
+ * @brief Binary Semaphore Delete Error
+ *
+ *  Occurs when trying to delete a Binary Semaphore that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_BIN_SEM_DELETE_ERR  ((int32)0xc400001C)
+
+/**
+ * @brief Counte Semaphore Delete Error
+ *
+ *  Occurs when trying to delete a Counting Semaphore that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_COUNT_SEM_DELETE_ERR  ((int32)0xc400001D)
+
+/**
+ * @brief Queue Delete Error
+ *
+ *  Occurs when trying to delete a Queue that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_QUEUE_DELETE_ERR  ((int32)0xc400001E)
+
+/**
+ * @brief File Close Error
+ *
+ *  Occurs when trying to close a file that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_FILE_CLOSE_ERR  ((int32)0xc400001F)
+
+/**
+ * @brief CDS Wrong Type Error
+ *
+ *  Occurs when Table Services is trying to delete a Critical Data Store that
+ *  is not a Critical Table Image or when Executive Services is trying to delete
+ *  a Critical Table Image.
+ *
+ */
+#define CFE_ES_CDS_WRONG_TYPE_ERR  ((int32)0xc4000020)
+
+/**
+ * @brief CDS Not Found Error
+ *
+ *  Occurs when a search of the Critical Data Store Registry does not find a
+ *  critical data store with the specified name.
+ *
+ */
+#define CFE_ES_CDS_NOT_FOUND_ERR   ((int32)0xc4000021)
+
+/**
+ * @brief CDS Owner Active Error
+ *
+ *  Occurs when an attempt was made to delete a CDS when an application
+ *  with the same name associated with the CDS is still present.  CDSs
+ *  can ONLY be deleted when Applications that created them are not present
+ *  in the system.
+ *
+ */
+#define CFE_ES_CDS_OWNER_ACTIVE_ERR ((int32)0xc4000022)
+
+
+/**
+ * @brief Application Cleanup Error
+ *
+ *  Occurs when an attempt was made to Clean Up an application 
+ *  which involves calling Table, EVS, and SB cleanup functions, then
+ *  deleting all ES resources, child tasks, and unloading the 
+ *  object module. The approach here is to keep going even though one
+ *  of these steps had an error. There will be syslog messages detailing
+ *  each problem.
+ *
+ */
+#define CFE_ES_APP_CLEANUP_ERR ((int32)0xc4000023)
+
+/**
+ * @brief Timer Delete Error
+ *
+ *  Occurs when trying to delete a Timer that belongs to a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_TIMER_DELETE_ERR ((int32)0xc4000024)
+
+/**
+ * @brief Buffer Not In Pool
+ *
+ *  The specified address is not in the memory pool.
+ *
+ */
+#define CFE_ES_BUFFER_NOT_IN_POOL ((int32)0xc4000025)
+
+
+/**
+ * @brief Task Delete Error
+ *
+ *  Occurs when trying to delete a task that ES
+ *  is cleaning up.
+ *
+ */
+#define CFE_ES_TASK_DELETE_ERR  ((int32)0xc4000026)
+
+/**
+ * @brief Operation Timed Out
+ *
+ *  Occurs if the timeout for a given operation was exceeded
+ *
+ */
+#define CFE_ES_OPERATION_TIMED_OUT ((int32)0xc4000027)
+
+/**
+ * @brief Library Already Loaded
+ *
+ *  Occurs if CFE_ES_LoadLibrary detects that the requested
+ *  library name is already loaded.
+ *
+ */
+#define CFE_ES_LIB_ALREADY_LOADED  ((int32)0x44000028)
+
+
+/**
+ * @brief System Log Message Truncated
+ *
+ *  This information code means the last syslog message was truncated
+ *  due to insufficient space in the log buffer.
+ *
+ */
+#define CFE_ES_ERR_SYS_LOG_TRUNCATED  ((int32)0x44000028)
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_ES_NOT_IMPLEMENTED  ((int32)0xc400ffff)
+
+
+/*
+************* FILE SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Bad Argument
+ *
+ *  A parameter given by a caller to a File Services API did not pass 
+ *  validation checks.
+ *
+ */
+#define CFE_FS_BAD_ARGUMENT             ((int32)0xc6000001)
+
+/**
+ * @brief Invalid Path
+ *
+ *  FS was unable to extract a filename from a path string
+ *
+ */
+#define CFE_FS_INVALID_PATH             ((int32)0xc6000002)
+
+/**
+ * @brief Filename Too Long
+ *
+ *  FS filename string is too long
+ *
+ */
+#define CFE_FS_FNAME_TOO_LONG           ((int32)0xc6000003)
+
+#ifndef CFE_OMIT_DEPRECATED_6_7
+/**
+ * @brief DEPRECATED: GZIP File Bad Data
+ * @deprecated
+ *
+ * The GZIP file contains invalid data and cannot be read
+ */
+#define CFE_FS_GZIP_BAD_DATA            ((int32)0xc6000004)
+
+/**
+ * @brief DEPRECATED: GZIP File Bad Code Block
+ * @deprecated
+ *
+ * The GZIP file codeblock is bad, which means the file is 
+ * most likely corrupted
+ */
+#define CFE_FS_GZIP_BAD_CODE_BLOCK      ((int32)0xc6000005)
+
+/**
+ * @brief DEPRECATED: GZIP Memory Buffer Exhausted
+ * @deprecated
+ *
+ * The memory buffer used by the decompression routine is 
+ * exhausted.
+ */
+#define CFE_FS_GZIP_NO_MEMORY           ((int32)0xc6000006)
+
+/**
+ * @brief DEPRECATED: GZIP CRC Error
+ * @deprecated
+ *
+ * There is a CRC error in the GZIP file, which means the 
+ * file is most likely corrupted.
+ */
+#define CFE_FS_GZIP_CRC_ERROR           ((int32)0xc6000007)
+
+/**
+ * @brief DEPRECATED: GZIP Length Error
+ * @deprecated
+ *
+ * There is a length error in the GZIP internal data 
+ * structures, which means the file is most likely corrupted.
+ */
+#define CFE_FS_GZIP_LENGTH_ERROR        ((int32)0xc6000008)
+
+/**
+ * @brief DEPRECATED: GZIP Write Error
+ * @deprecated
+ *
+ * An error occurred trying to write the uncompressed 
+ * file.
+ */
+#define CFE_FS_GZIP_WRITE_ERROR         ((int32)0xc6000009)
+
+/**
+ * @brief DEPRECATED: GZIP Read Error
+ * @deprecated
+ *
+ * An error occurred trying to read the GZIP file
+ */ 
+#define CFE_FS_GZIP_READ_ERROR          ((int32)0xc600000A)
+
+/**
+ *  @brief DEPRECATED: GZIP Open Output Error
+ * @deprecated
+ *
+ * An error occurred trying to open the DestinationFile
+ * where the GZIP file will be uncompressed. The 
+ * function must be able to open a new write-only file to
+ * store the uncompressed file in.
+ */
+#define CFE_FS_GZIP_OPEN_OUTPUT         ((int32)0xc600000B)
+
+/**
+ * @brief DEPRECATED: GZIP Open Input Error
+ * @deprecated
+ *
+ * An error occurred trying to open the GZIP file 
+ * to be decompressed. The function must be able to open
+ * the GZIP file as read-only in order to decompress it 
+ * to a new file ( most likely in a RAM disk )
+ */
+#define CFE_FS_GZIP_OPEN_INPUT          ((int32)0xc600000C)
+
+/**
+ * @brief DEPRECATED: GZIP Read Header Error
+ * @deprecated
+ *
+ * An error occured trying to read the GZIP file header,
+ * which means the file is most likely corrupted or 
+ * not a valid GZIP file.
+ */
+#define CFE_FS_GZIP_READ_ERROR_HEADER   ((int32)0xc600000D)
+
+/**
+ * @brief DEPRECATED: GZIP Index Error
+ * @deprecated
+ *
+ * An error occurred trying to read the GZIP index, 
+ * which means the file is most likely corrupted.
+ */
+#define CFE_FS_GZIP_INDEX_ERROR         ((int32)0xc600000E)
+
+/**
+ * @brief DEPRECATED: GZIP Not Zip File
+ * @deprecated
+ *
+ * The file to be decompressed is not a valid GZIP file
+ */
+#define CFE_FS_GZIP_NON_ZIP_FILE        ((int32)0xc600000F)
+
+#endif /* CFE_OMIT_DEPRECATED_6_7 */
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_FS_NOT_IMPLEMENTED  ((int32)0xc600ffff)
+
+#ifndef CFE_OMIT_DEPRECATED_6_7 
+/*
+************* OSAPI STATUS CODES *************
+*/
+
+// #define CFE_OS_ERROR                    (OS_ERROR)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_INVALID_POINTER          (OS_INVALID_POINTER)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERROR_ADDRESS_MISALIGNED (OS_ERROR_ADDRESS_MISALIGNED)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERROR_TIMEOUT            (OS_ERROR_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_INVALID_INT_NUM          (OS_INVALID_INT_NUM)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_SEM_FAILURE              (OS_SEM_FAILURE)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_SEM_TIMEOUT              (OS_SEM_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_QUEUE_EMPTY              (OS_QUEUE_EMPTY)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_QUEUE_FULL               (OS_QUEUE_FULL)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_QUEUE_TIMEOUT            (OS_QUEUE_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_QUEUE_INVALID_SIZE       (OS_QUEUE_INVALID_SIZE)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_QUEUE_ID_ERROR           (OS_QUEUE_ID_ERROR)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_NAME_TOO_LONG        (OS_ERR_NAME_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_NO_FREE_IDS          (OS_ERR_NO_FREE_IDS)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_NAME_TAKEN           (OS_ERR_NAME_TAKEN)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_INVALID_ID           (OS_ERR_INVALID_ID)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_NAME_NOT_FOUND       (OS_ERR_NAME_NOT_FOUND)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_SEM_NOT_FULL         (OS_ERR_SEM_NOT_FULL)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_ERR_INVALID_PRIORITY     (OS_ERR_INVALID_PRIORITY)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_FS_ERROR                 (OS_ERROR)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_FS_ERR_INVALID_POINTER   (OS_INVALID_POINTER)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_FS_ERR_PATH_TOO_LONG     (OS_FS_ERR_PATH_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_FS_ERR_NAME_TOO_LONG     (OS_FS_ERR_NAME_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OS_FS_ERR_DRIVE_NOT_CREATED (OS_FS_ERR_DRIVE_NOT_CREATED)  /**< @brief DEPRECATED @deprecated */
+// #define CFE_OSAPI_NOT_IMPLEMENTED       (OS_ERR_NOT_IMPLEMENTED)  /**< @brief DEPRECATED @deprecated */
+
+#endif /* CFE_OMIT_DEPRECATED_6_7 */
+
+/*
+************* SOFTWARE BUS SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Time Out
+ *
+ *  In #CFE_SB_RcvMsg, this return value indicates that a packet has not 
+ *  been received in the time given in the "timeout" parameter.
+ *
+ */
+#define CFE_SB_TIME_OUT         ((int32)0xca000001)
+
+
+/**
+ * @brief No Message
+ *
+ *  When "Polling" a pipe for a message in #CFE_SB_RcvMsg, this return 
+ *  value indicates that there was not a message on the pipe.
+ *
+ */
+#define CFE_SB_NO_MESSAGE       ((int32)0xca000002)
+
+
+/**
+ * @brief Bad Argument
+ *
+ *  A parameter given by a caller to a Software Bus API did not pass 
+ *  validation checks.
+ *
+ */
+#define CFE_SB_BAD_ARGUMENT     ((int32)0xca000003)
+
+
+/**
+ * @brief Max Pipes Met
+ *
+ *  This error code will be returned from #CFE_SB_CreatePipe when the  
+ *  SB cannot accomodate the request to create a pipe because the maximum 
+ *  number of pipes (#CFE_PLATFORM_SB_MAX_PIPES) are in use. This configuration 
+ *  parameter is defined in the cfe_platform_cfg.h file.
+ *
+ */
+#define CFE_SB_MAX_PIPES_MET    ((int32)0xca000004)
+
+
+/**
+ * @brief Pipe Create Error
+ *
+ *  The maximum number of queues(#OS_MAX_QUEUES) are in use. Or possibly a 
+ *  lower level problem with creating the underlying queue has occurred
+ *  such as a lack of memory. If the latter is the problem, the status 
+ *  code displayed in the event must be tracked.       
+ *
+ */
+#define CFE_SB_PIPE_CR_ERR      ((int32)0xca000005)
+
+
+/**
+ * @brief Pipe Read Error
+ *
+ *  This return value indicates an error at the Queue read level. This
+ *  error typically cannot be corrected by the caller. Some possible 
+ *  causes are: queue was not properly initialized or created, the number
+ *  of bytes read from the queue was not the number of bytes requested in
+ *  the read. The queue id is invalid. Similar errors regarding the pipe
+ *  will be caught by higher level code in the Software Bus.
+ *
+ */
+#define CFE_SB_PIPE_RD_ERR      ((int32)0xca000006)
+
+
+/**
+ * @brief Message Too Big
+ *
+ *  The size field in the message header indicates the message exceeds the  
+ *  max Software Bus message size. The max size is defined by   
+ *  configuration parameter #CFE_MISSION_SB_MAX_SB_MSG_SIZE in cfe_mission_cfg.h
+ *
+ */
+#define CFE_SB_MSG_TOO_BIG      ((int32)0xca000007)
+
+
+/**
+ * @brief Buffer Allocation Error
+ *
+ *  This error code will be returned from #CFE_SB_SendMsg when the memory 
+ *  in the SB message buffer pool has been depleted. The amount of memory  
+ *  in the pool is dictated by the configuration parameter 
+ *  #CFE_PLATFORM_SB_BUF_MEMORY_BYTES specified in the cfe_platform_cfg.h file. Also 
+ *  the memory statistics, including current utilization figures and high 
+ *  water marks for the SB Buffer memory pool can be monitored by sending 
+ *  a Software Bus command to send the SB statistics packet.
+ *
+ */
+#define CFE_SB_BUF_ALOC_ERR     ((int32)0xca000008)
+
+
+/**
+ * @brief Max Messages Met
+ *
+ *  Will be returned when calling one of the SB subscription API's if the
+ *  SB routing table cannot accomodate another unique message ID because
+ *  the platform configuration parameter #CFE_PLATFORM_SB_MAX_MSG_IDS has been met.
+ *
+ */
+#define CFE_SB_MAX_MSGS_MET     ((int32)0xca000009)
+
+
+/**
+ * @brief Max Destinations Met
+ *
+ *  Will be returned when calling one of the SB subscription API's if the
+ *  SB routing table cannot accomodate another destination for a 
+ *  particular the given message ID. This occurs when the number of   
+ *  destinations in use meets the platform configuration parameter 
+ *  #CFE_PLATFORM_SB_MAX_DEST_PER_PKT.
+ *
+ */
+#define CFE_SB_MAX_DESTS_MET    ((int32)0xca00000a)
+
+
+/**
+ * @brief No Subscribers
+ *
+ *  This error code is returned by the #CFE_SB_Unsubscribe API if there has
+ *  not been an entry in the routing tables for the MsgId/PipeId given as
+ *  parameters.
+ */
+#define CFE_SB_NO_SUBSCRIBERS   ((int32)0xca00000b)
+
+
+/**
+ * @brief Internal Error
+ *
+ *  This error code will be returned by the #CFE_SB_Subscribe API if the 
+ *  code detects an internal index is out of range. The most likely 
+ *  cause would be a Single Event Upset.
+ *
+ */
+#define CFE_SB_INTERNAL_ERR     ((int32)0xca00000c)
+
+
+/**
+ * @brief Wrong Message Type
+ *
+ *  This error code will be returned when a request such as #CFE_SB_SetMsgTime
+ *  is made on a packet that does not include a field for msg time.
+ *
+ */
+#define CFE_SB_WRONG_MSG_TYPE     ((int32)0xca00000d)
+
+
+/**
+ * @brief Buffer Invalid
+ *
+ *  This error code will be returned when a request to release or send a
+ *  zero copy buffer is invalid, such as if the handle or buffer is not
+ *  correct or the buffer was previously released.
+ *
+ */
+#define CFE_SB_BUFFER_INVALID     ((int32)0xca00000e)
+
+
+/**
+ * @brief No Message Recieved
+ *
+ *  When trying to determine the last senders ID, this return 
+ *  value indicates that there was not a message recived on the pipe.
+ *
+ */
+#define CFE_SB_NO_MSG_RECV       ((int32)0xca00000f)
+
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_SB_NOT_IMPLEMENTED  ((int32)0xca00ffff)
+
+/*
+************* TABLE SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Invalid Handle
+ *
+ *  The calling Application attempted to pass a
+ *  Table handle that represented too large an index or
+ *  identified a Table Access Descriptor that was not used.
+ *
+ */
+#define CFE_TBL_ERR_INVALID_HANDLE ((int32)0xcc000001)
+
+/** 
+ * @brief Invalid Name
+ *
+ *  The calling Application attempted to register a table whose
+ *  name length exceeded the platform configuration value of
+ *  #CFE_MISSION_TBL_MAX_NAME_LENGTH or was zero characters long.
+ *
+ */
+#define CFE_TBL_ERR_INVALID_NAME ((int32)0xcc000002)
+
+/**
+ * @brief Invalid Size
+ *
+ *  The calling Application attempted to register a table:
+ *    a) that was a double buffered table with size greater than #CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE
+ *    b) that was a single buffered table with size greater than #CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE
+ *    c) that had a size of zero
+ *
+ */
+#define CFE_TBL_ERR_INVALID_SIZE ((int32)0xcc000003)
+
+/**
+ * @brief Update Pending
+ *
+ *   The calling Application has identified a table that has a load pending.
+ *
+ */
+#define CFE_TBL_INFO_UPDATE_PENDING ((int32)0x4c000004)
+
+/**
+ * @brief Never Loaded
+ *
+ *  Table has not been loaded with data.
+ *
+ */
+#define CFE_TBL_ERR_NEVER_LOADED ((int32)0xcc000005)
+
+/**
+ * @brief Registry Full
+ *
+ *  An application attempted to create a table and the Table
+ *  registry already contained #CFE_PLATFORM_TBL_MAX_NUM_TABLES in it.
+ *
+ */
+#define CFE_TBL_ERR_REGISTRY_FULL ((int32)0xcc000006)
+
+/**
+ * @brief Duplicate Warning
+ *
+ *  This is an error that the registration is trying to replace
+ *  an existing table with the same name.  The previous table 
+ *  stays in place and the new table is rejected.
+ *
+ */
+#define CFE_TBL_WARN_DUPLICATE ((int32)0x4c000007)
+
+/**
+ * @brief No Access
+ *
+ *   The calling application either failed when calling #CFE_TBL_Register,
+ *   failed when calling #CFE_TBL_Share or forgot to call either one.
+ *
+ */
+#define CFE_TBL_ERR_NO_ACCESS   ((int32)0xcc000008)
+
+/**
+ * @brief Unregistered
+ *
+ *  The calling application is trying to access a table that has
+ *  been unregistered.
+ *
+ */
+#define CFE_TBL_ERR_UNREGISTERED ((int32)0xcc000009)
+
+/**
+ * @brief Bad Application ID
+ *
+ *  The calling application does not have a legitimate Application ID.
+ *  Most likely cause is a failure to register with the cFE via the
+ *  #CFE_ES_RegisterApp function.
+ *
+ */
+#define CFE_TBL_ERR_BAD_APP_ID ((int32)0xcc00000A)
+
+/**
+ * @brief Handles Full
+ *
+ *   An application attempted to create a table and the Table
+ *   Handle Array already used all CFE_PLATFORM_TBL_MAX_NUM_HANDLES in it.
+ *
+ */
+#define CFE_TBL_ERR_HANDLES_FULL ((int32)0xcc00000B)
+
+/**
+ * @brief Duplicate Table With Different Size
+ *
+ *  An application attempted to register a table with the same name
+ *  as a table that is already in the registry.  The size of the new
+ *  table is different from the size already in the registry.
+ *
+ */
+#define CFE_TBL_ERR_DUPLICATE_DIFF_SIZE ((int32)0xcc00000C)
+
+/**
+ * @brief Dupicate Table And Not Owned
+ *
+ *  An application attempted to register a table with the same name
+ *  as a table that is already in the registry.  The previously registered
+ *  table is owned by a different application.
+ *
+ */
+#define CFE_TBL_ERR_DUPLICATE_NOT_OWNED ((int32)0xcc00000D)
+
+/**
+ * @brief Updated
+ *
+ *  The calling Application has identified a table that has been updated.<BR>
+ *  \b NOTE: This is a nominal return code informing the calling application
+ *  that the table identified in the call has had its contents updated since
+ *  the last time the application obtained its address or status.
+ *
+ */
+#define CFE_TBL_INFO_UPDATED ((int32)0x4c00000E)
+
+/**
+ * @brief No Buffer Available
+ *
+ *  The calling Application has tried to allocate a working buffer but
+ *  none were available.
+ *
+ */
+#define CFE_TBL_ERR_NO_BUFFER_AVAIL ((int32)0xcc00000F)
+
+/**
+ * @brief Dump Only Error
+ *
+ *  The calling Application has attempted to perform a load on a
+ *  table that was created with "Dump Only" attributes.
+ *
+ */
+#define CFE_TBL_ERR_DUMP_ONLY ((int32)0xcc000010)
+
+/**
+ * @brief Illegal Source Type
+ *
+ *  The calling Application called #CFE_TBL_Load with an illegal
+ *  value for the second parameter.
+ *
+ */
+#define CFE_TBL_ERR_ILLEGAL_SRC_TYPE ((int32)0xcc000011)
+
+/**
+ * @brief Load In Progress
+ *
+ *  The calling Application called #CFE_TBL_Load when another Application
+ *  was trying to load the table.
+ *
+ */
+#define CFE_TBL_ERR_LOAD_IN_PROGRESS ((int32)0xcc000012)
+
+/**
+ * @brief File Not Found
+ *
+ *  The calling Application called #CFE_TBL_Load with a bad filename.
+ *
+ */
+#define CFE_TBL_ERR_FILE_NOT_FOUND ((int32)0xcc000013)
+
+/**
+ * @brief File Too Large
+ *
+ *  The calling Application called #CFE_TBL_Load with a filename that specified a file
+ *  that contained more data than the size of the table OR which contained more data
+ *  than specified in the table header.
+ *
+ */
+#define CFE_TBL_ERR_FILE_TOO_LARGE ((int32)0xcc000014)
+
+/**
+ * @brief Short File Warning
+ *
+ *  The calling Application called #CFE_TBL_Load with a filename that specified a file
+ *  that started with the first byte of the table but contained less data than the size of the table.
+ *  It should be noted that #CFE_TBL_WARN_PARTIAL_LOAD also indicates a partial load (one that starts
+ *  at a non-zero offset).
+ *
+ */
+#define CFE_TBL_WARN_SHORT_FILE ((int32)0x4c000015)
+
+/**
+ * @brief Bad Content ID
+ *
+ *  The calling Application called #CFE_TBL_Load with a filename that specified a file
+ *  whose content ID was not that of a table image.
+ *
+ */
+#define CFE_TBL_ERR_BAD_CONTENT_ID ((int32)0xcc000016)
+
+/**
+ * @brief No Update Pending
+ *
+ *  The calling Application has attempted to update a table without a pending load.
+ *
+ */
+#define CFE_TBL_INFO_NO_UPDATE_PENDING ((int32)0x4c000017)
+
+/**
+ * @brief Table Locked
+ *
+ *  The calling Application tried to update a table that is locked by another user.
+ *
+ */
+#define CFE_TBL_INFO_TABLE_LOCKED ((int32)0x4c000018)
+
+/**
+ * Validation Pending
+ *
+ *   The calling Application should call #CFE_TBL_Validate for the specified table.
+ *
+ */
+#define CFE_TBL_INFO_VALIDATION_PENDING ((int32)0x4c000019)
+
+/**
+ * No Validation Pending
+ *
+ *  The calling Application tried to validate a table that did not have a validation request pending.
+ *
+ */
+#define CFE_TBL_INFO_NO_VALIDATION_PENDING ((int32)0x4c00001A)
+
+/**
+ * @brief Bad Subtype ID
+ *
+ *  The calling Application tried to access a table file whose Subtype identifier indicated it was not
+ *  a table image file.
+ *
+ */
+#define CFE_TBL_ERR_BAD_SUBTYPE_ID ((int32)0xcc00001B)
+
+/**
+ * @brief File Size Inconsistent
+ *
+ *  The calling Application tried to access a table file whose Subtype identifier indicated it was not
+ *  a table image file.
+ *
+ */
+#define CFE_TBL_ERR_FILE_SIZE_INCONSISTENT ((int32)0xcc00001C)
+
+/**
+ * @brief No Standard Header
+ *
+ *  The calling Application tried to access a table file whose standard cFE File Header was the wrong size, etc.
+ *
+ */
+#define CFE_TBL_ERR_NO_STD_HEADER ((int32)0xcc00001D)
+
+/**
+ * @brief No Table Header
+ *
+ *  The calling Application tried to access a table file whose standard cFE
+ *  Table File Header was the wrong size, etc.
+ *
+ */
+#define CFE_TBL_ERR_NO_TBL_HEADER ((int32)0xcc00001E)
+
+
+/**
+ * @brief Filename Too Long
+ *
+ *  The calling Application tried to load a table using a filename
+ *  that was too long.
+ *
+ */
+#define CFE_TBL_ERR_FILENAME_TOO_LONG ((int32)0xcc00001F)
+
+
+/**
+ * @brief File For Wrong Table
+ *
+ *  The calling Application tried to load a table using a file whose
+ *  header indicated that it was for a different table.
+ *
+ */
+#define CFE_TBL_ERR_FILE_FOR_WRONG_TABLE ((int32)0xcc000020)
+
+
+/**
+ * @brief Load Incomplete
+ *
+ *  The calling Application tried to load a table file whose header
+ *  claimed the load was larger than what was actually read from the file.
+ *
+ */
+#define CFE_TBL_ERR_LOAD_INCOMPLETE ((int32)0xcc000021)
+
+
+/**
+ * @brief Partial Load Warning
+ *
+ *  The calling Application tried to load a table file whose header
+ *  claimed the load did not start with the first byteIt should be noted
+ *  that #CFE_TBL_WARN_SHORT_FILE also indicates a partial load.
+ *
+ */
+#define CFE_TBL_WARN_PARTIAL_LOAD ((int32)0x4c000022)
+
+
+/**
+ * @brief Partial Load Error
+ *
+ *  The calling Application tried to load a table file whose header
+ *  claimed the load did not start with the first byte and the table
+ *  image had NEVER been loaded before.  Partial loads are not allowed
+ *  on uninitialized tables.  It should be noted that
+ *  #CFE_TBL_WARN_SHORT_FILE also indicates a partial load.
+ *
+ */
+#define CFE_TBL_ERR_PARTIAL_LOAD ((int32)0xcc000023)
+
+
+/**
+ * @brief Dump Pending
+ *
+ *  The calling Application should call #CFE_TBL_Manage for the specified table.
+ *  The ground has requested a dump of the Dump-Only table and needs to synchronize
+ *  with the owning application.
+ *
+ */
+#define CFE_TBL_INFO_DUMP_PENDING ((int32)0x4c000024)
+
+
+/**
+ * @brief Invalid Options
+ *
+ *   The calling Application has used an illegal combination of table options.
+ *   A summary of the illegal combinations are as follows:
+ *   \par   #CFE_TBL_OPT_USR_DEF_ADDR cannot be combined with any of the following:
+ *             -# #CFE_TBL_OPT_DBL_BUFFER
+ *             -# #CFE_TBL_OPT_LOAD_DUMP
+ *             -# #CFE_TBL_OPT_CRITICAL
+ *   \par   #CFE_TBL_OPT_DBL_BUFFER cannot be combined with the following:
+ *             -# #CFE_TBL_OPT_USR_DEF_ADDR
+ *             -# #CFE_TBL_OPT_DUMP_ONLY
+ *
+ */
+#define CFE_TBL_ERR_INVALID_OPTIONS ((int32)0xcc000025)
+
+
+/**
+ * @brief Not Critical Warning
+ *
+ *  The calling Application attempted to register a table as "Critical".
+ *  Table Services failed to create an appropriate Critical Data Store
+ *  (See System Log for reason) to save the table contents.  The table
+ *  will be treated as a normal table from now on.
+ *
+ */
+#define CFE_TBL_WARN_NOT_CRITICAL ((int32)0x4c000026)
+
+
+/**
+ * @brief Recovered Table
+ *
+ *  The calling Application registered a critical table whose previous
+ *  contents were discovered in the Critical Data Store.  The discovered
+ *  contents were copied back into the newly registered table as the
+ *  table's initial contents.<BR>
+ *  \b NOTE: In this situation, the contents of the table are \b NOT 
+ *  validated using the table's validation function.
+ *
+ */
+#define CFE_TBL_INFO_RECOVERED_TBL ((int32)0x4c000027)
+
+
+/**
+ * @brief Bad Spacecraft ID
+ *
+ *  The selected table file failed validation for Spacecraft ID.
+ *  The platform configuration file has verification of table files
+ *  enabled for Spacecraft ID and an attempt was made to load a table
+ *  with an invalid Spacecraft ID in the table file header.
+ *
+ */
+#define CFE_TBL_ERR_BAD_SPACECRAFT_ID   ((int32)0xcc000028)
+
+
+/**
+ * @brief Bad Processor ID
+ *
+ *  The selected table file failed validation for Processor ID.
+ *  The platform configuration file has verification of table files
+ *  enabled for Processor ID and an attempt was made to load a table
+ *  with an invalid Processor ID in the table file header.
+ *
+ */
+#define CFE_TBL_ERR_BAD_PROCESSOR_ID    ((int32)0xcc000029)
+
+/**
+ * @brief Message Error
+ *
+ *  Error code indicating that the TBL command was not processed
+ *  successfully and that the error counter should be incremented.
+ */
+#define CFE_TBL_MESSAGE_ERROR           ((int32)0xcc00002a)
+
+/**
+**  Error code indicating that the TBL file is shorter than
+**  indicated in the file header.
+*/
+#define CFE_TBL_ERR_SHORT_FILE          ((int32)0xcc00002b)
+
+/**
+**  Error code indicating that the TBL file could not be
+**  opened by the OS.
+*/
+#define CFE_TBL_ERR_ACCESS              ((int32)0xcc00002c)
+
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_TBL_NOT_IMPLEMENTED ((int32)0xcc00ffff)
+
+
+/*
+************* TIME SERVICES STATUS CODES *************
+*/
+
+/**
+ * @brief Not Implemented
+ *
+ *  Current version of cFE does not have the function or the feature
+ *  of the function implemented.  This could be due to either an early
+ *  build of the cFE for this platform or the platform does not support
+ *  the specified feature.
+ *
+ */
+#define CFE_TIME_NOT_IMPLEMENTED ((int32)0xce00ffff)
+
+/**
+ * @brief Internal Only
+ *
+ *  One of the TIME Services API functions to set the time with data
+ *  from an external time source has been called, but TIME Services
+ *  has been commanded to not accept external time data.  However,
+ *  the command is still a signal for the Time Server to generate
+ *  a "time at the tone" command packet using internal data.
+ *
+ */
+#define CFE_TIME_INTERNAL_ONLY ((int32)0xce000001)
+
+/**
+ * @brief Out Of Range
+ *
+ *  One of the TIME Services API functions to set the time with data
+ *  from an external time source has been called, but TIME Services
+ *  has determined that the new time data is invalid.  However,
+ *  the command is still a signal for the Time Server to generate
+ *  a "time at the tone" command packet using internal data.
+ *
+ * Note that the test for invalid time update data only occurs if TIME
+ *        Services has previously been commanded to set the clock state
+ *        to "valid".
+ */
+#define CFE_TIME_OUT_OF_RANGE ((int32)0xce000002)
+
+/**
+ * @brief Too Many Sync Callbacks
+ *
+ *  An attempt to register too many cFE Time Services Synchronization
+ *  callbacks has been made.  Only one callback function is allowed per
+ *  application.  It is expected that the application itself will
+ *  distribute the single callback to child threads as needed.
+ *
+ */
+#define CFE_TIME_TOO_MANY_SYNCH_CALLBACKS ((int32)0xce000003)
+
+/**
+ * @brief Callback Not Registered
+ *
+ *  An attempt to unregister a cFE Time Services Synchronization
+ *  callback has failed because the specified callback function was not
+ *  located in the Synchronization Callback Registry.
+ *
+ */
+#define CFE_TIME_CALLBACK_NOT_REGISTERED ((int32)0xce000004)
+/**@}*/
+
+#endif  /* _cfe_error_ */

--- a/message-utilities/cfe_components/cfe_sb_util.c
+++ b/message-utilities/cfe_components/cfe_sb_util.c
@@ -37,7 +37,7 @@
 #include "cfe_sb.h"
 #include "ccsds.h"
 // #include "osapi.h"
-// #include "cfe_error.h"
+#include "cfe_error.h"
 
 #include <string.h>
 
@@ -304,46 +304,46 @@ void CFE_SB_InitMsg(void           *MsgPtr,
 // }/* end CFE_SB_TimeStampMsg */
 
 
-// /*
-//  * Function: CFE_SB_GetCmdCode - See API and header file for details
-//  */
-// uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
-// {
-//     CFE_SB_CmdHdr_t     *CmdHdrPtr;
+/*
+ * Function: CFE_SB_GetCmdCode - See API and header file for details
+ */
+uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
+{
+    CFE_SB_CmdHdr_t     *CmdHdrPtr;
 
-//     /* if msg type is telemetry or there is no secondary hdr, return 0 */
-//     if((CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_TLM)||(CCSDS_RD_SHDR(MsgPtr->Hdr) == 0)){
-//         return 0;
-//     }/* end if */
+    /* if msg type is telemetry or there is no secondary hdr, return 0 */
+    if((CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_TLM)||(CCSDS_RD_SHDR(MsgPtr->Hdr) == 0)){
+        return 0;
+    }/* end if */
 
-//     /* Cast the input pointer to a Cmd Msg pointer */
-//     CmdHdrPtr = (CFE_SB_CmdHdr_t *)MsgPtr;
+    /* Cast the input pointer to a Cmd Msg pointer */
+    CmdHdrPtr = (CFE_SB_CmdHdr_t *)MsgPtr;
 
-//     return CCSDS_RD_FC(CmdHdrPtr->Cmd.Sec);
-// }/* end CFE_SB_GetCmdCode */
+    return CCSDS_RD_FC(CmdHdrPtr->Cmd.Sec);
+}/* end CFE_SB_GetCmdCode */
 
 
-// /*
-//  * Function: CFE_SB_SetCmdCode - See API and header file for details
-//  */
-// int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
-//                       uint16 CmdCode)
-// {
-//     CFE_SB_CmdHdr_t     *CmdHdrPtr;
+/*
+ * Function: CFE_SB_SetCmdCode - See API and header file for details
+ */
+int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
+                      uint16 CmdCode)
+{
+    CFE_SB_CmdHdr_t     *CmdHdrPtr;
 
-//     /* if msg type is telemetry or there is no secondary hdr... */
-//     if((CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_TLM)||(CCSDS_RD_SHDR(MsgPtr->Hdr) == 0)){
-//         return CFE_SB_WRONG_MSG_TYPE;
-//     }/* end if */
+    /* if msg type is telemetry or there is no secondary hdr... */
+    if((CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_TLM)||(CCSDS_RD_SHDR(MsgPtr->Hdr) == 0)){
+        return CFE_SB_WRONG_MSG_TYPE;
+    }/* end if */
 
-//     /* Cast the input pointer to a Cmd Msg pointer */
-//     CmdHdrPtr = (CFE_SB_CmdHdr_t *)MsgPtr;
+    /* Cast the input pointer to a Cmd Msg pointer */
+    CmdHdrPtr = (CFE_SB_CmdHdr_t *)MsgPtr;
 
-//     CCSDS_WR_FC(CmdHdrPtr->Cmd.Sec,CmdCode);
+    CCSDS_WR_FC(CmdHdrPtr->Cmd.Sec,CmdCode);
 
-//     return CFE_SUCCESS;
+    return CFE_SUCCESS;
 
-// }/* end CFE_SB_SetCmdCode */
+}/* end CFE_SB_SetCmdCode */
 
 
 // /*

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -14,6 +14,7 @@
 #include "imu_driver_msgs.h"
 #include "obc_msgs.h"
 #include "drive_arc_msg.h"
+#include "tlm_output_msgs.h"
 #define SUCCESS 1
 #define FAILURE 0
 
@@ -38,33 +39,52 @@ typedef union {
         uint8_t cmd_data_buf_ptr;
     };
 
+    // telemetry messages
     MOONRANGER_Pose_Tlm_t Pose_Tlm;
-    POSE_HkTlm_t Pose_estimator_Tlm;
-    MOONRANGER_WheelVelocity_Command_t WheelVelocity_Command;
-    MOONRANGER_Teleop_Cmd_t Teleop_Cmd;
-    OBC_BatteryEnable_Cmd_t Battery_En_Cmd;
-    MOONRANGER_RoverInit_Tlm_t rover_init_indicator;
+    MOONRANGER_WheelVelocity_Command_t WheelVelocity_Command_Tlm;
+    MOONRANGER_RoverInit_Tlm_t RoverInit_Tlm;
     MOONRANGER_Goal_Tlm_t Goal_Tlm;
+    MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;
+
+    OBC_Peripheral_Sensor_Tlm_t PeripheralSensor_Tlm;
+
+    STEREO_HkTlm_t StereoHk_Tlm;
+    STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
+
+    TLM_OUTPUT_HkTlm_t TlmOutputHk_Tlm;
+    TLM_OUTPUT_DataTypes_t TlmOutputDataTypes_Tlm;
+
+    POSE_HkTlm_t Pose_estimator_Tlm;
+
+    IMU_DRIVER_HkTlm_t Imu_driver_Tlm;
+
+    // command messages
+    MOONRANGER_Teleop_Cmd_t Teleop_Cmd;
+    
     OBC_Set_Heater_State_Cmd_t HeaterControl_Cmd;
     OBC_Set_Switch_State_Cmd_t PowerSwitching_Cmd;
     OBC_Reset_Switch_Cmd_t ResetPowerSwitch_Cmd;
-    OBC_WifiEnable_Cmd_t WiFi_Enable_Cmd;
     OBC_NSS_Set_Params_Cmd_t NSSSetParams_Cmd;
     OBC_Set_Motor_PID_Cmd_t Set_Motor_Pid_Cmd;
     OBC_Set_Solar_Panel_State_Cmd_t Set_Solar_Panel_State_Cmd;
     OBC_Set_Wheel_Speed_All_Cmd_t Set_Wheel_Speed_All_Cmd;
-    STEREO_HkTlm_t StereoHk_Tlm;
-    STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
-    STEREO_Noop_t StereoNoOp_Tlm;
-    STEREO_ResetCounters_t StereoResetCounters_Tlm;
-    STEREO_Process_t StereoProcess_Tlm;
-    STEREO_Receive_Camera_Calib_t StereoReceiveCameraCalib_Tlm;
-    STEREO_NoArgsCmd_t StereoNoArgs_Tlm;
-    IMU_DRIVER_HkTlm_t Imu_driver_Tlm;
-    MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;
-    OBC_Peripheral_Sensor_Tlm_t PeripheralSensor_Tlm;
-    OBC_BatteryEnable_Cmd_t BatteryEnable_Tlm;
-    OBC_WifiEnable_Cmd_t WifiEnable_Tlm;
+    OBC_BatteryEnable_Cmd_t BatteryEnable_Cmd;
+    OBC_WifiEnable_Cmd_t WifiEnable_Cmd;
+    
+    STEREO_Noop_t StereoNoOp_Cmd;
+    STEREO_ResetCounters_t StereoResetCounters_Cmd;
+    STEREO_Process_t StereoProcess_Cmd;
+    STEREO_Receive_Camera_Calib_t StereoReceiveCameraCalib_Cmd;
+    STEREO_NoArgsCmd_t StereoNoArgs_Cmd;
+
+    TLM_OUTPUT_Noop_t TlmOutputNoOp_Cmd;
+    TLM_OUTPUT_ResetCounters_t TlmOutputResetCounters_Cmd;
+    TLM_OUTPUT_RemoveAll_t TlmOutputRemoveAll_Cmd;
+    TLM_OUTPUT_SendDataTypes_t TlmOutputSendDataTypes_Cmd;
+    TLM_OUTPUT_AddPacket_t TlmOutputAddPacket_Cmd;
+    TLM_OUTPUT_RemovePacket_t TlmOutputRemovePacket_Cmd;
+    TLM_OUTPUT_EnableOutput_t TlmOutputEnableOutput_Cmd;
+
 } message_builder_u;
 
 int messageExtract(void* MsgPtr, int msg_len_bytes,

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -50,6 +50,9 @@ typedef union {
     OBC_Reset_Switch_Cmd_t ResetPowerSwitch_Cmd;
     OBC_WifiEnable_Cmd_t WiFi_Enable_Cmd;
     OBC_NSS_Set_Params_Cmd_t NSSSetParams_Cmd;
+    OBC_Set_Motor_PID_Cmd_t Set_Motor_Pid_Cmd;
+    OBC_Set_Solar_Panel_State_Cmd_t Set_Solar_Panel_State_Cmd;
+    OBC_Set_Wheel_Speed_All_Cmd_t Set_Wheel_Speed_All_Cmd;
     STEREO_HkTlm_t StereoHk_Tlm;
     STEREO_SendPclMsgTlm_t StereoSendPcl_Tlm;
     STEREO_Noop_t StereoNoOp_Tlm;

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -41,7 +41,7 @@ typedef union {
 
     // telemetry messages
     MOONRANGER_Pose_Tlm_t Pose_Tlm;
-    MOONRANGER_WheelVelocity_Command_t WheelVelocity_Command_Tlm;
+    MOONRANGER_WheelVelocity_Command_t WheelVelocity_Command;
     MOONRANGER_RoverInit_Tlm_t RoverInit_Tlm;
     MOONRANGER_Goal_Tlm_t Goal_Tlm;
     MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;
@@ -94,7 +94,10 @@ int messageBuildTlm(void* dataPtr, message_builder_u* msg_container,
                     int data_len_bytes, int32 msgId);
 int messageBuildCmd(void* dataPtr, message_builder_u* msg_container,
                     int data_len_bytes, int32 msgId);
+int messageBuildCmdWithCode(void* dataPtr, message_builder_u* msg_container,
+                            int data_len_bytes, int32 msgId, uint16 cmdCode);
 
 CFE_SB_MsgId_t GetMsgId(void* MsgPtr);
+uint16 GetCmdCode(void* MsgPtr);
 
 #endif

--- a/message-utilities/src/message_builder.c
+++ b/message-utilities/src/message_builder.c
@@ -59,10 +59,19 @@ int messageBuildTlm(void* dataPtr, message_builder_u* msg_container,int data_len
 
 int messageBuildCmd(void* dataPtr, message_builder_u* msg_container,int data_len_bytes, int32 msgId)
 {
+  // force command code to be 0 if unspecified
+  return messageBuildCmdWithCode(dataPtr, msg_container, data_len_bytes, msgId, 0);
+}
+
+int messageBuildCmdWithCode(void* dataPtr, message_builder_u* msg_container,int data_len_bytes, int32 msgId, uint16 cmdCode)
+{
   int header_length = CFE_SB_CMD_HDR_SIZE;
 
   // Fill the header
   CFE_SB_InitMsg(&msg_container->msg_buf_ptr, (CFE_SB_MsgId_t)msgId, header_length+ data_len_bytes, true);
+
+  // set command code
+  CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t)&msg_container->msg_buf_ptr, cmdCode);
 
   // Fill the data
   // Sanity check what we are about to do

--- a/message-utilities/src/utilities.c
+++ b/message-utilities/src/utilities.c
@@ -4,3 +4,8 @@ CFE_SB_MsgId_t GetMsgId(void *ptr) {
     CFE_SB_Msg_t *MsgPtr = ptr;
     return CFE_SB_GetMsgId(MsgPtr);
 }
+
+uint16 GetCmdCode(void *ptr) {
+    CFE_SB_MsgPtr_t MsgPtr = ptr;
+    return CFE_SB_GetCmdCode(MsgPtr);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
- Add tlm output messages to the message builder union.
- Refactor the message builder union code (group similar messages together).
- Add functionality to set the command code of a command: 
    - A new function `messageBuildCmdWithCode` has been added for this.
    - The new function `getCmdCode` obtains the command code of a message and is used for testing purposes on the backend.
    - Uncommented functions `CFE_SB_GetCmdCode` and `CFE_SB_SetCmdCode` in `cfe_sb_util.c`.
    - Added file `cfe_error.h` from the moonranger-rover-flight repo.
 
## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #196 on the MCS backend.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Tested with appropriate tests on the MCS backend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
