### PR TITLE
added epsm cmd and telem msgs

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -135,10 +135,16 @@
 #define OBC_BATT_ENABLE_CMD_MID 0x1ACB            // enable battery
 #define OBC_MASTER_COMM_ENABLE_CMD_MID 0x1ACC     // enable master msp
 #define OBC_POWER_SWITCH_ENABLE_CMD_MID 0x1ACD    // enable power switching msp
+#define OBC_GET_EPSM_SAI_STATUS_MID 0x1ACE        // ask for EPSM SAI status
+#define OBC_GET_EPSM_CONVERTER_STATUS_MID \
+    0x1ACF   // ask for EPSM Converter status
 #define OBC_PERIPHERAL_SENSOR_TLM_MID \
     0x0AC0   // receive all peripheral sensor data
 #define OBC_HEALTH_TLM_MID \
     0x0AC1   // receive all peripheral computer health data
+#define OBC_EPSM_SAI_STATUS_TLM_MID 0x0AC2   // all EPSM SAI telemetry
+#define OBC_EPSM_CONVERTER_STATUS_TLM_MID \
+    0x0AC3   // all EPSM converter telemetry
 /**
  * GROUND Command Message IDs
  * @note Command message IDs in this section should fit within

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -145,6 +145,7 @@
 #define OBC_EPSM_SAI_STATUS_TLM_MID 0x0AC2   // all EPSM SAI telemetry
 #define OBC_EPSM_CONVERTER_STATUS_TLM_MID \
     0x0AC3   // all EPSM converter telemetry
+#define OBC_BM2_STATUS_TLM_MID 0x0AC4
 /**
  * GROUND Command Message IDs
  * @note Command message IDs in this section should fit within

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -137,7 +137,8 @@
 #define OBC_POWER_SWITCH_ENABLE_CMD_MID 0x1ACD    // enable power switching msp
 #define OBC_GET_EPSM_SAI_STATUS_MID 0x1ACE        // ask for EPSM SAI status
 #define OBC_GET_EPSM_CONVERTER_STATUS_MID \
-    0x1ACF   // ask for EPSM Converter status
+    0x1ACF                              // ask for EPSM Converter status
+#define OBC_GET_BM2_STATUS_MID 0x1AD0   // ask for battery module status
 #define OBC_PERIPHERAL_SENSOR_TLM_MID \
     0x0AC0   // receive all peripheral sensor data
 #define OBC_HEALTH_TLM_MID \

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -137,8 +137,10 @@
 #define OBC_POWER_SWITCH_ENABLE_CMD_MID 0x1ACD    // enable power switching msp
 #define OBC_GET_EPSM_SAI_STATUS_MID 0x1ACE        // ask for EPSM SAI status
 #define OBC_GET_EPSM_CONVERTER_STATUS_MID \
-    0x1ACF                              // ask for EPSM Converter status
-#define OBC_GET_BM2_STATUS_MID 0x1AD0   // ask for battery module status
+    0x1ACF                                // ask for EPSM Converter status
+#define OBC_GET_BM2_STATUS_MID 0x1AD0     // ask for battery module status
+#define OBC_I2C_USER_DEFINED_MID 0x1AD1   // send a user defined i2c msg
+
 #define OBC_PERIPHERAL_SENSOR_TLM_MID \
     0x0AC0   // receive all peripheral sensor data
 #define OBC_HEALTH_TLM_MID \
@@ -147,6 +149,8 @@
 #define OBC_EPSM_CONVERTER_STATUS_TLM_MID \
     0x0AC3   // all EPSM converter telemetry
 #define OBC_BM2_STATUS_TLM_MID 0x0AC4
+#define OBC_I2C_USER_DEFINED_TELEM \
+    0x0AC5   // i2c response to user define command
 /**
  * GROUND Command Message IDs
  * @note Command message IDs in this section should fit within

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -303,7 +303,7 @@ typedef struct {
     uint8_t valid;             // if this converter's data is valid
 } ConverterState_t;
 
-    typedef struct {
+typedef struct {
     uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
     ConverterState_t Status[4];   // 3.3V, 5V, 12V, AUX in order
 } OS_PACK OBC_EPSM_ConverterStatus_t;
@@ -312,6 +312,23 @@ typedef union {
     CFE_SB_Msg_t MsgHdr;
     ConverterState_t OBC_EPSM_response;
 } OBC_EPSM_ConverterState_buffer_t;
+
+typedef struct {
+    uint16_t time_to_full;    // in minutes 65535 means not charging
+    uint16_t time_to_empty;   // in minutes 6555 means not discharing
+        uint8_t charge_state;     // 0-100% charge state
+    uint8_t valid; //if the msg is valid;
+} BatteryModuleState_t;
+
+typedef struct {
+    uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
+    BatteryModuleState_t battery_module[2];
+} OS_PACK OBC_BM_Status_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    OBC_BM_Status_t OBC_BM_response;
+} OBC_EPSM_BM_Status_t;
 
 #define OBC_EPSM_CONVERTER_STATUS_TELEM_LEN sizeof(OBC_EPSM_ConverterStatus_t)
 

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -301,7 +301,7 @@ typedef struct {
     int16_t amps;              // units are milliamps
     uint8_t converter_state;   // see EPSM:TEL? 8 documentation
     uint8_t valid;             // if this converter's data is valid
-} ConverterState_t
+} ConverterState_t;
 
     typedef struct {
     uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -278,6 +278,10 @@ typedef union {
 /**************************************************************************
  * EPSM Message Definitions
  **************************************************************************/
+#define NUM_POWER_RAILS 4   // 3.3V, 5V, 12V, AUX in order
+#define NUM_BATT_MODULES 2
+#define MAX_USER_CMD_LEN 46   // max length of user defined I2C command
+
 typedef struct {
     uint16_t volt;       // units are millivolts
     int16_t amps;        // units are milliamps
@@ -306,7 +310,7 @@ typedef struct {
 
 typedef struct {
     uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
-    ConverterState_t Status[4];   // 3.3V, 5V, 12V, AUX in order
+    ConverterState_t Status[NUM_POWER_RAILS];   // 3.3V, 5V, 12V, AUX in order
 } OS_PACK OBC_EPSM_ConverterStatus_t;
 
 typedef union {
@@ -325,7 +329,7 @@ typedef struct {
 
 typedef struct {
     uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
-    BatteryModuleState_t battery_module[2];
+    BatteryModuleState_t battery_module[NUM_BATT_MODULES];
 } OS_PACK OBC_BM_Status_t;
 
 typedef union {
@@ -336,7 +340,7 @@ typedef union {
 #define OBC_EPSM_BM_STATUS_TELEM_LEN sizeof(OBC_BM_Status_t)
 
 typedef struct {
-    uint8_t tx_data[46];
+    uint8_t tx_data[MAX_USER_CMD_LEN];
     uint8_t i2c_slave_addr;
     uint8_t tx_bytes;
     uint8_t rx_bytes;
@@ -355,7 +359,7 @@ typedef union {
 #define OBC_I2C_USER_DEFINED_LEN sizeof(OBC_I2C_USER_DEFINED_TX_t)
 
 typedef struct {
-    uint8_t tx_data[46];
+    uint8_t rx_data[MAX_USER_CMD_LEN];
 } user_rx_data_t;
 
 typedef struct {

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -105,7 +105,8 @@ typedef struct {
     uint32_t duration;   // seconds
 } Set_Wheel_Speed_All_Cmd_Payload;
 
-#define OBC_SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(Set_Wheel_Speed_All_Cmd_Payload)
+#define OBC_SET_WHEEL_SPEED_ALL_PAYLOAD_LEN \
+    sizeof(Set_Wheel_Speed_All_Cmd_Payload)
 
 // cFS command structure
 typedef struct {
@@ -258,7 +259,7 @@ typedef union {
 #define OBC_SET_HEATER_STATE_CMD_LEN sizeof(OBC_Set_Heater_State_Cmd_t)
 
 typedef struct {
-    uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+    uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
     set_heater_state_all_payload_t payload;
 } OS_PACK OBC_Set_Heater_State_All_Cmd_t;
 
@@ -313,11 +314,13 @@ typedef union {
     ConverterState_t OBC_EPSM_response;
 } OBC_EPSM_ConverterState_buffer_t;
 
+#define OBC_EPSM_CONVERTER_STATUS_TELEM_LEN sizeof(OBC_EPSM_ConverterStatus_t)
+
 typedef struct {
     uint16_t time_to_full;    // in minutes 65535 means not charging
     uint16_t time_to_empty;   // in minutes 6555 means not discharing
-        uint8_t charge_state;     // 0-100% charge state
-    uint8_t valid; //if the msg is valid;
+    uint8_t charge_state;     // 0-100% charge state
+    uint8_t valid;            // if the msg is valid;
 } BatteryModuleState_t;
 
 typedef struct {
@@ -328,8 +331,43 @@ typedef struct {
 typedef union {
     CFE_SB_Msg_t MsgHdr;
     OBC_BM_Status_t OBC_BM_response;
-} OBC_EPSM_BM_Status_t;
+} OBC_EPSM_BM_Status_buffer_t;
 
-#define OBC_EPSM_CONVERTER_STATUS_TELEM_LEN sizeof(OBC_EPSM_ConverterStatus_t)
+#define OBC_EPSM_BM_STATUS_TELEM_LEN sizeof(OBC_BM_Status_t)
+
+typedef struct {
+    uint8_t tx_data[46];
+    uint8_t i2c_slave_addr;
+    uint8_t tx_bytes;
+    uint8_t rx_bytes;
+} user_tx_data_t;
+
+typedef struct {
+    uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
+    user_tx_data_t tx_data;
+} OS_PACK OBC_I2C_USER_DEFINED_TX_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    OBC_I2C_USER_DEFINED_TX_t user_tx;
+} OBC_I2C_USER_DEFINED_TX_buffer_t;
+
+#define OBC_I2C_USER_DEFINED_LEN sizeof(OBC_I2C_USER_DEFINED_TX_t)
+
+typedef struct {
+    uint8_t tx_data[46];
+} user_rx_data_t;
+
+typedef struct {
+    uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
+    user_rx_data_t rx_data;
+} OS_PACK OBC_I2C_USER_DEFINED_RX_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    OBC_I2C_USER_DEFINED_RX_t user_tx;
+} OBC_I2C_USER_DEFINED_RX_buffer_t;
+
+#define OBC_I2C_USER_DEFINED_TELEM_LEN sizeof(OBC_I2C_USER_DEFINED_RX_t)
 
 #endif /* _obc_msgs_h */

--- a/fsw/public_inc/obc_msgs.h
+++ b/fsw/public_inc/obc_msgs.h
@@ -49,11 +49,15 @@ typedef OBC_NoArgsCmd_t OBC_BatteryEnable_Cmd_t;
 typedef OBC_NoArgsCmd_t OBC_WifiEnable_Cmd_t;
 typedef OBC_NoArgsCmd_t OBC_MasterCommsEnable_Cmd_t;
 typedef OBC_NoArgsCmd_t OBC_PowerSwitchingEnable_Cmd_t;
+typedef OBC_NoArgsCmd_t OBC_GetEPSMSAIStatus_Cmd_t;
+typedef OBC_NoArgsCmd_t OBC_GetEPSMConverter_Cmd_t;
 
 // TODO - do we need the buffer definitions as per messages below?
 
 // Message sizes
 #define BATTERY_ENABLE_CMD_LNGTH sizeof(OBC_BatteryEnable_Cmd_t)
+#define EPSM_GET_SAI_LNGTH sizeof(OBC_GetEPSMSAIStatus_Cmd_t)
+#define EPSM_GET_CONVERTER_LNGTH sizeof(OBC_GetEPSMConverter_Cmd_t)
 #define WIFI_ENABLE_CMD_LNGTH sizeof(OBC_WifiEnable_Cmd_t)
 #define POWER_SWITCHING_ENABLE_CMD_LNGTH sizeof(OBC_PowerSwitchingEnable_Cmd_t)
 #define MASTER_COMMS_ENABLE_CMD_LNGTH sizeof(OBC_MasterCommsEnable_Cmd_t)
@@ -269,5 +273,46 @@ typedef union {
 
 // Message sizes
 #define OBC_SET_HEATER_STATE_ALL_CMD_LEN sizeof(OBC_Set_Heater_State_All_Cmd_t)
+
+/**************************************************************************
+ * EPSM Message Definitions
+ **************************************************************************/
+typedef struct {
+    uint16_t volt;       // units are millivolts
+    int16_t amps;        // units are milliamps
+    uint8_t SAI_state;   // see EPSM:TEL? 0 documentation
+    uint8_t valid;       // if this SAI's data is valid
+} SAIStatus_t;
+
+typedef struct {
+    uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
+    SAIStatus_t Status[6];
+} OS_PACK OBC_EPSM_SAIStatus_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    OBC_EPSM_SAIStatus_t OBC_EPSM_response;
+} OBC_EPSM_SAIStatus_buffer_t;
+
+#define OBC_EPSM_SAI_STATUS_TELEM_LEN sizeof(OBC_EPSM_SAIStatus_t)
+
+typedef struct {
+    uint16_t volt;             // units are millivolts
+    int16_t amps;              // units are milliamps
+    uint8_t converter_state;   // see EPSM:TEL? 8 documentation
+    uint8_t valid;             // if this converter's data is valid
+} ConverterState_t
+
+    typedef struct {
+    uint8_t TlmHdr[CFE_SB_TLM_HDR_SIZE];
+    ConverterState_t Status[4];   // 3.3V, 5V, 12V, AUX in order
+} OS_PACK OBC_EPSM_ConverterStatus_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    ConverterState_t OBC_EPSM_response;
+} OBC_EPSM_ConverterState_buffer_t;
+
+#define OBC_EPSM_CONVERTER_STATUS_TELEM_LEN sizeof(OBC_EPSM_ConverterStatus_t)
 
 #endif /* _obc_msgs_h */

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -123,9 +123,11 @@ typedef union {
     MAPPER_ResetCounters_t MapperReseteCounters_Cmd;
     MAPPER_NoArgsCmd_t MapperNoArgs_Cmd;
 
-<<<<<<< HEAD
     OBC_I2C_USER_DEFINED_TX_t I2C_user_defined_Cmd;
-=======
+    OBC_BM_Status_t BM_status_Telem;
+    OBC_EPSM_ConverterStatus_t EPSM_Converter_Telem;
+    OBC_EPSM_SAIStatus_t EPSM_SAI_Telem;
+
     VEHICLE_CONTROLLER_Noop_t VehicleControllerNoOp_Cmd;
     VEHICLE_CONTROLLER_ResetCounters_t VehicleControllerResetCounters_Cmd;
     VEHICLE_CONTROLLER_UpdateParams_t VehicleControllerUpdateParams_Cmd;
@@ -135,7 +137,6 @@ typedef union {
     TBL_MANAGER_ResetCounters_t TblmanagerResetCounters_Cmd;
     TBL_MANAGER_Update_t TblManagerUpdate_Cmd;
     TBL_MANAGER_NoArgsCmd_t TblManagerNoargs_Cmd;
->>>>>>> main
 
 } message_builder_u;
 

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -112,6 +112,8 @@ typedef union {
     MAPPER_ResetCounters_t MapperReseteCounters_Cmd;
     MAPPER_NoArgsCmd_t MapperNoArgs_Cmd;
 
+    OBC_I2C_USER_DEFINED_TX_t I2C_user_defined_Cmd;
+
 } message_builder_u;
 
 int messageExtract(void* MsgPtr, int msg_len_bytes,

--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -124,6 +124,7 @@ typedef union {
     MAPPER_NoArgsCmd_t MapperNoArgs_Cmd;
 
     OBC_I2C_USER_DEFINED_TX_t I2C_user_defined_Cmd;
+    OBC_I2C_USER_DEFINED_RX_t I2C_user_defined_Telem;
     OBC_BM_Status_t BM_status_Telem;
     OBC_EPSM_ConverterStatus_t EPSM_Converter_Telem;
     OBC_EPSM_SAIStatus_t EPSM_SAI_Telem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds commands to get the SAI and converter status of the EPSM
## Description
OBC_GetEPSMSAIStatus_Cmd_t gets the SAI 1-6 status (volts, amps and status byte). Will respond with OBC_EPSM_SAIStatus_t

OBC_GetEPSMConverter_Cmd_t gets the 3.3, 5, 12 and AUX converter status (volts, amps and status byte). Will respond with OBC_EPSM_ConverterStatus_t 

~~At this time, I am unsure if we should make these messages on-demand or be bundled with the peripheral telem messages. However, the main goal of the PR is to establish the format and type of data that will be sent and not the exact behavior~~
EDIT: per the software reference manual for the SupMCU, 75-100ms is needed between a request for telem and a read telem. Thus it is not possible to query and receive all 6 SAI telemetry or all 4 converter telemetry within the time frame needed for peripheral telem messages. Therefore, they can't be bundled with peripheral telem messages 
## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the `CONTRIBUTING.md` file
- [X] I have applied the .clang-format file to my changes
- [X] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [X] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [X] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
