### PR TITLE
Add #defines for the stereo camera ids to common types so all apps can access them

### DIFF
--- a/fsw/public_inc/moonranger_common_types.h
+++ b/fsw/public_inc/moonranger_common_types.h
@@ -22,3 +22,29 @@
  */
 typedef double float64;
 typedef float float32;
+
+/**
+ * Camera ID definitions
+*/
+/* Defines the number of cameras on the robot. Used for the length of the camera
+   calibration data structures. */
+#define STEREO_NUMBER_OF_CAMERAS 4
+// the left camera of the robot as seen facing forwards
+// adjacent to "front right", and diagonally opposite "rear left"
+#define STEREO_FRONT_LEFT_CAMERA_ID 1
+// the right camera of the robot as seen facing forwards
+// adjacent to "front left", and diagonally opposite "rear right"
+#define STEREO_FRONT_RIGHT_CAMERA_ID 2
+// the left camera of the robot as seen facing rearwards
+// adjacent to "rear right", and diagonally opposite "front left"
+#define STEREO_REAR_LEFT_CAMERA_ID 4
+// the right camera of the robot as seen facing rearwards
+// adjacent to "rear left", and diagonally opposite "front right"
+#define STEREO_REAR_RIGHT_CAMERA_ID 3
+//these temporary defintions exist to get perception running as quickly as
+//possible. They are obsolete and eventually all of the perception code should
+//move to using the definitons above
+#define STEREO_HISTORICAL_FRONT_LEFT_CAMERA_ID 0
+#define STEREO_HISTORICAL_FRONT_RIGHT_CAMERA_ID 1
+#define STEREO_HISTORICAL_REAR_LEFT_CAMERA_ID 2
+#define STEREO_HISTORICAL_REAR_RIGHT_CAMERA_ID 3

--- a/fsw/public_inc/moonranger_common_types.h
+++ b/fsw/public_inc/moonranger_common_types.h
@@ -14,7 +14,7 @@
  *
  ****************************************************************/
 
-//include for all common types from the OSAL.
+// include for all common types from the OSAL.
 #include "common_types.h"
 
 /**
@@ -25,7 +25,7 @@ typedef float float32;
 
 /**
  * Camera ID definitions
-*/
+ */
 /* Defines the number of cameras on the robot. Used for the length of the camera
    calibration data structures. */
 #define STEREO_NUMBER_OF_CAMERAS 4
@@ -41,9 +41,9 @@ typedef float float32;
 // the right camera of the robot as seen facing rearwards
 // adjacent to "rear left", and diagonally opposite "front right"
 #define STEREO_REAR_RIGHT_CAMERA_ID 3
-//these temporary defintions exist to get perception running as quickly as
-//possible. They are obsolete and eventually all of the perception code should
-//move to using the definitons above
+// these temporary defintions exist to get perception running as quickly as
+// possible. They are obsolete and eventually all of the perception code should
+// move to using the definitons above
 #define STEREO_HISTORICAL_FRONT_LEFT_CAMERA_ID 0
 #define STEREO_HISTORICAL_FRONT_RIGHT_CAMERA_ID 1
 #define STEREO_HISTORICAL_REAR_LEFT_CAMERA_ID 2

--- a/fsw/public_inc/moonranger_common_types.h
+++ b/fsw/public_inc/moonranger_common_types.h
@@ -28,7 +28,7 @@ typedef float float32;
  */
 /* Defines the number of cameras on the robot. Used for the length of the camera
    calibration data structures. */
-#define STEREO_NUMBER_OF_CAMERAS 4
+#define NUMBER_OF_CAMERAS 4
 // the left camera of the robot as seen facing forwards
 // adjacent to "front right", and diagonally opposite "rear left"
 #define STEREO_FRONT_LEFT_CAMERA_ID 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/670#discussion_r834636627

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

Make test passes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
