### PR TITLE
Created init command for FTP app

### DIFF
--- a/fsw/public_inc/ftp_control_msg.h
+++ b/fsw/public_inc/ftp_control_msg.h
@@ -4,26 +4,16 @@
  *
  * @brief     Type definition for Moonranger FTP control message
  *
- * @version   1.0
- * @date      2 March 2021
- *
  * @authors 	Ethan Muchnik
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  *
  ****************************************************************/
 
-#ifndef _pose_msg_h_
-#define _pose_msg_h_
+#ifndef _ftp_control_h_
+#define _ftp_control_h_
 
 #include "cfe_sb.h"
 #include "common_types.h"
-
-/*
-** Type definition (MOONRANGER pose)
-*/
-
-// TODO move this to common location
-typedef double float64;
 
 typedef struct {
     CFE_TIME_SysTime_t timeStamp;
@@ -33,7 +23,7 @@ typedef struct {
 } MOONRANGER_FTP_Control_t;
 
 /**
- * Type definition (MOONRANGER pose telemetry)
+ * Type definition (MOONRANGER FTP control telemetry)
  * @note includes CFS TLM Header with timestamp
  */
 typedef struct {
@@ -42,7 +32,7 @@ typedef struct {
 } OS_PACK MOONRANGER_FTP_Control_Tlm_t;
 
 /**
- * Buffer to hold pose data prior to sending
+ * Buffer to hold FTP control data prior to sending
  * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
  */
 typedef union {
@@ -54,4 +44,4 @@ typedef union {
 #define MOONRANGER_FTP_CONTROL_LNGTH sizeof(MOONRANGER_FTP_Control_t)
 #define MOONRANGER_FTP_CONTROL_TLM_LNGTH sizeof(MOONRANGER_FTP_Control_Tlm_t)
 
-#endif /* _pose_msg_h_ */
+#endif /* _ftp_control_h_ */

--- a/fsw/public_inc/ftp_init_msg.h
+++ b/fsw/public_inc/ftp_init_msg.h
@@ -2,10 +2,7 @@
  *
  * @file      ftp_init_msg.h
  *
- * @brief     Type definition for Moonranger FTP sync message
- *
- * @version   1.0
- * @date      2 March 2021
+ * @brief     Type definition for Moonranger FTP Init message
  *
  * @authors 	Ethan Muchnik
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
@@ -18,19 +15,12 @@
 #include "cfe_sb.h"
 #include "common_types.h"
 
-/*
-** Type definition (MOONRANGER pose)
-*/
-
-// TODO move this to common location
-typedef double float64;
-
 typedef struct {
     CFE_TIME_SysTime_t timeStamp;
 } MOONRANGER_FTP_Init_t;
 
 /**
- * Type definition (MOONRANGER pose telemetry)
+ * Type definition (MOONRANGER Init telemetry)
  * @note includes CFS TLM Header with timestamp
  */
 typedef struct {
@@ -39,7 +29,7 @@ typedef struct {
 } OS_PACK MOONRANGER_FTP_Init_Tlm_t;
 
 /**
- * Buffer to hold pose data prior to sending
+ * Buffer to hold init data prior to sending
  * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
  */
 typedef union {
@@ -51,4 +41,4 @@ typedef union {
 #define MOONRANGER_FTP_INIT_LNGTH sizeof(MOONRANGER_FTP_Init_t)
 #define MOONRANGER_FTP_INIT_TLM_LNGTH sizeof(MOONRANGER_FTP_Init_Tlm_t)
 
-#endif /* ftp_send_all_h_ */
+#endif /* ftp_init_all_h_ */

--- a/fsw/public_inc/ftp_init_msg.h
+++ b/fsw/public_inc/ftp_init_msg.h
@@ -1,0 +1,54 @@
+/****************************************************************
+ *
+ * @file      ftp_init_msg.h
+ *
+ * @brief     Type definition for Moonranger FTP sync message
+ *
+ * @version   1.0
+ * @date      2 March 2021
+ *
+ * @authors 	Ethan Muchnik
+ * @author 		Carnegie Mellon University, Planetary Robotics Lab
+ *
+ ****************************************************************/
+
+#ifndef _ftp_init_h_
+#define _ftp_init_h_
+
+#include "cfe_sb.h"
+#include "common_types.h"
+
+/*
+** Type definition (MOONRANGER pose)
+*/
+
+// TODO move this to common location
+typedef double float64;
+
+typedef struct {
+    CFE_TIME_SysTime_t timeStamp;
+} MOONRANGER_FTP_Init_t;
+
+/**
+ * Type definition (MOONRANGER pose telemetry)
+ * @note includes CFS TLM Header with timestamp
+ */
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    MOONRANGER_FTP_Init_t data;
+} OS_PACK MOONRANGER_FTP_Init_Tlm_t;
+
+/**
+ * Buffer to hold pose data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    MOONRANGER_FTP_Init_Tlm_t FTPSyncTlm;
+} MOONRANGER_FTP_Init_Buffer_t;
+
+// Message sizes
+#define MOONRANGER_FTP_INIT_LNGTH sizeof(MOONRANGER_FTP_Init_t)
+#define MOONRANGER_FTP_INIT_TLM_LNGTH sizeof(MOONRANGER_FTP_Init_Tlm_t)
+
+#endif /* ftp_send_all_h_ */

--- a/fsw/public_inc/ftp_msg.h
+++ b/fsw/public_inc/ftp_msg.h
@@ -4,9 +4,6 @@
  *
  * @brief     Message types for the ftp app
  *
- * @version     1.0
- * @date   		3/12/2021
- *
  * @authors 	Ethan Muchnik
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  *

--- a/fsw/public_inc/ftp_send_all_msg.h
+++ b/fsw/public_inc/ftp_send_all_msg.h
@@ -2,10 +2,7 @@
  *
  * @file      ftp_send_all_msg.h
  *
- * @brief     Type definition for Moonranger FTP sync message
- *
- * @version   1.0
- * @date      2 March 2021
+ * @brief     Type definition for Moonranger FTP Send All message
  *
  * @authors 	Ethan Muchnik
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
@@ -18,19 +15,12 @@
 #include "cfe_sb.h"
 #include "common_types.h"
 
-/*
-** Type definition (MOONRANGER pose)
-*/
-
-// TODO move this to common location
-typedef double float64;
-
 typedef struct {
     CFE_TIME_SysTime_t timeStamp;
 } MOONRANGER_FTP_Send_All_t;
 
 /**
- * Type definition (MOONRANGER pose telemetry)
+ * Type definition (MOONRANGER FTP send all telemetry)
  * @note includes CFS TLM Header with timestamp
  */
 typedef struct {
@@ -39,7 +29,7 @@ typedef struct {
 } OS_PACK MOONRANGER_FTP_Send_All_Tlm_t;
 
 /**
- * Buffer to hold pose data prior to sending
+ * Buffer to hold FTP send all data prior to sending
  * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
  */
 typedef union {

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -182,6 +182,7 @@
 #define FTP_SEND_HK_MID 0x1BD1
 #define FTP_CONTROL 0x1BD2
 #define FTP_SEND_ALL 0x1BD3
+#define FTP_INIT 0x1BD4
 #define FTP_HK_TLM_MID 0x0BD0
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I created an init command for FTP in case there was a need to manually init the server connection again in case of some sort disconnection though the FTP app still thinks there is a connection

## Description
<!--- Describe your changes in detail -->

I just added an init command file and the corresponding msgid in the msgid file

## 
<!--- Why is this change required? What problem does it solve? -->
This adds extra debugging functionality in case the rover loses conneciton and needs to init it again.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->This has been tested with informal unit tests by runing ./core-tx2i in tandom with the modified ftp_app.c
<!--- Include details of your testing environment, tests ran to see how -->
My testing environment was in an 20.04 ubuntu VM using ./core-tx2i
<!--- your change affects other areas of the code, etc. -->
My change only affects ftp-app.c
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [] I have made corresponding changes to the design documentation 
- [] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [x] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
