### PR TITLE
Remove WheelVelocityCmd_t message

### DIFF
--- a/message-utilities/include/message_builder.h
+++ b/message-utilities/include/message_builder.h
@@ -11,7 +11,6 @@
 #include "rover_init_msg.h"
 #include "stereo_reconstructor_msgs.h"
 #include "teleop_msg.h"
-#include "wheel_velocity_command_msg.h"
 #include "imu_driver_msgs.h"
 #include "obc_msgs.h"
 #include "drive_arc_msg.h"
@@ -44,7 +43,6 @@ typedef union {
 
     // telemetry messages
     MOONRANGER_Pose_Tlm_t Pose_Tlm;
-    MOONRANGER_WheelVelocity_Command_t WheelVelocity_Command;
     MOONRANGER_RoverInit_Tlm_t RoverInit_Tlm;
     MOONRANGER_Goal_Tlm_t Goal_Tlm;
     MOONRANGER_DriveArc_Tlm_t DriveArc_Tlm;

--- a/message-utilities/test/test_builder.c
+++ b/message-utilities/test/test_builder.c
@@ -29,56 +29,56 @@ Hex encoding of CCSDS Packed Message (this is the payload of the UDP packet)
 */
 
 void test_message_builder_extract(void) {
-    // test stuff
-    message_builder_u msg_container;
+    // // test stuff
+    // message_builder_u msg_container;
 
-    unsigned char test_data[32] = {
-        0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
-        0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
+    // unsigned char test_data[32] = {
+    //     0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
+    //     0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
+    //     0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
 
-    messageExtract(&test_data, 32, &msg_container);
+    // messageExtract(&test_data, 32, &msg_container);
 
-    printf("%d\n", msg_container.WheelVelocity_Command.data.duration);
-    printf("%f\n", msg_container.WheelVelocity_Command.data.leftFront);
-    printf("%f\n", msg_container.WheelVelocity_Command.data.rightFront);
-    printf("%f\n", msg_container.WheelVelocity_Command.data.leftBack);
-    printf("%f\n", msg_container.WheelVelocity_Command.data.rightBack);
+    // printf("%d\n", msg_container.WheelVelocity_Command.data.duration);
+    // printf("%f\n", msg_container.WheelVelocity_Command.data.leftFront);
+    // printf("%f\n", msg_container.WheelVelocity_Command.data.rightFront);
+    // printf("%f\n", msg_container.WheelVelocity_Command.data.leftBack);
+    // printf("%f\n", msg_container.WheelVelocity_Command.data.rightBack);
 }
 
 void test_message_builder_build(void) {
-    message_builder_u msg_container;
+    // message_builder_u msg_container;
 
-    // Fill data
-    MOONRANGER_WheelVelocityCmd_t test_message;
-    test_message.duration = 10;
-    test_message.leftFront = 8.0f;
-    test_message.rightFront = 4.0f;
-    test_message.leftBack = 6.0f;
-    test_message.rightBack = 2.0f;
+    // // Fill data
+    // MOONRANGER_WheelVelocityCmd_t test_message;
+    // test_message.duration = 10;
+    // test_message.leftFront = 8.0f;
+    // test_message.rightFront = 4.0f;
+    // test_message.leftBack = 6.0f;
+    // test_message.rightBack = 2.0f;
 
-    unsigned char test_data[32] = {
-        0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
-        0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
+    // unsigned char test_data[32] = {
+    //     0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
+    //     0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
+    //     0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
 
-    messageBuildTlm(&test_message, &msg_container, sizeof(test_message), 0x0D05);
+    // messageBuildTlm(&test_message, &msg_container, sizeof(test_message), 0x0D05);
 
-    unsigned char* ptr = &msg_container.msg_buf_ptr;
+    // unsigned char* ptr = &msg_container.msg_buf_ptr;
 
-    for (int i = 0; i < 32; i++) printf("%x ", *(ptr + i));
-    printf("\n");
+    // for (int i = 0; i < 32; i++) printf("%x ", *(ptr + i));
+    // printf("\n");
 }
 
 void test_get_msg_id(void) {
-    unsigned char test_data[32] = {
-        0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
-        0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
+    // unsigned char test_data[32] = {
+    //     0x0d, 0x05, 0xc0, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x00,
+    //     0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00,
+    //     0x80, 0x40, 0x00, 0x00, 0xc0, 0x40, 0x00, 0x00, 0x00, 0x40};
 
-    uint16 msgID = (uint16)(GetMsgId(test_data));
+    // uint16 msgID = (uint16)(GetMsgId(test_data));
 
-    printf("Got message ID %d\n", msgID);
+    // printf("Got message ID %d\n", msgID);
 }
 
 int main() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove **unused** WheelVelocityCmd_t message.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Tested on MCS backend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
