### PR TITLE
Add tracing address and message IDs

### DIFF
--- a/fsw/public_inc/master_comms_bus_protocol.h
+++ b/fsw/public_inc/master_comms_bus_protocol.h
@@ -29,7 +29,9 @@ typedef enum
     E6 = 6,    // 0b00000110, E6 - NSS Interface Address
     E7 = 9,    // 0b00001001, E7 - Sun Sensor Interface Address
     E8 = 10,   // 0b00001010, E8 - Power Switching Address
-    E9 = 12,   // 0b00001100  E9 - Heater Controller Address
+    E9 = 12,   // 0b00001100, E9 - Heater Controller Address
+    TC = 0xD8, // 0b11011000, Trace probe collector
+    TM = 0xDB, // 0b11011011, Trace probe mutation actuator
 } msp_address_t;
 
 typedef enum
@@ -53,6 +55,8 @@ typedef enum
     SET_HEATER_STATE_MID = 39,        // 0b00100111,
     SET_HEATER_STATE_ALL_MID = 53,    // 0b00110101,
     HEATER_TELEM_MID = 40,            // 0b00101000,
+    TRACE_PACKET = 200,               // 0b11001000,
+    TRACE_MUTATION = 203,             // 0b11001011,
 } master_comms_bus_msg_id_t;
 
 typedef struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add tracing address and message ID variants.

This enables the MSPs and test suite to filter out valid trace data egress and control plane ingest frames.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
