### PR TITLE
Added static asserts for struct alignment checkts

### DIFF
--- a/fsw/public_inc/heater_control_msgs.h
+++ b/fsw/public_inc/heater_control_msgs.h
@@ -5,8 +5,6 @@
  * @brief     definitions for all master comms bus messages for heater
  *controller
  *
- * @date   		20 Feb 2022
- *
  * @authors 	Tenzin Crouch
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  *
@@ -64,10 +62,13 @@ typedef struct {
 
 #define SET_HEATER_STATE_PAYLOAD_LEN sizeof(set_heater_state_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (2 == SET_HEATER_STATE_PAYLOAD_LEN),
     "set_heater_state_payload_t struct size incorrect (expected 2 bytes)");
+
+static_assert(((SET_HEATER_STATE_PAYLOAD_LEN % 2) == 0),
+              "set_heater_state_payload_t not 16 bit aligned");
 
 // set all heater state command payload
 typedef struct {
@@ -76,10 +77,13 @@ typedef struct {
 
 #define SET_HEATER_STATE_ALL_PAYLOAD_LEN sizeof(set_heater_state_all_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
-    (14 == SET_HEATER_STATE_ALL_PAYLOAD_LEN),
-    "set_heater_state_payload_all_t struct size incorrect (expected 14 bytes)");
+    (16 == SET_HEATER_STATE_ALL_PAYLOAD_LEN),
+    "set_heater_state_payload_all_t struct size incorrect (expected 16 bytes)");
+
+static_assert(((SET_HEATER_STATE_ALL_PAYLOAD_LEN % 2) == 0),
+              "set_heater_state_payload_all_t struct not 16 bit aligned");
 
 // heater telemetry payload
 typedef struct {
@@ -92,10 +96,13 @@ typedef struct {
 
 #define HEATER_TELEM_PAYLOAD_LEN sizeof(heater_telem_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
-    (44 == HEATER_TELEM_PAYLOAD_LEN),
-    "heater_telem_payload_t struct size incorrect (expected 44 bytes)");
+    (52 == HEATER_TELEM_PAYLOAD_LEN),
+    "heater_telem_payload_t struct size incorrect (expected 52 bytes)");
+
+static_assert(((HEATER_TELEM_PAYLOAD_LEN % 2) == 0),
+              "heater_telem_payload_t struct not 16 bit aligned");
 
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
@@ -104,59 +111,70 @@ static_assert(
 typedef struct {
     main_bus_hdr_t msg_hdr;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } get_heater_telem_cmd_t;
 
 #define GET_HEATER_TELEM_CMD_LEN sizeof(get_heater_telem_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (12 == GET_HEATER_TELEM_CMD_LEN),
-    "get_heater_telem_cmd_t struct size incorrect (expected 44 bytes)");
+    "get_heater_telem_cmd_t struct size incorrect (expected 12 bytes)");
+
+static_assert(((GET_HEATER_TELEM_CMD_LEN % 4) == 0),
+              "get_heater_telem_cmd_t struct not 32 bit aligned");
 
 // set heater state command
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_heater_state_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } set_heater_state_cmd_t;
 
 #define SET_HEATER_STATE_CMD_LEN sizeof(set_heater_state_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (14 == SET_HEATER_STATE_CMD_LEN),
     "set_heater_state_cmd_t struct size incorrect (expected 14 bytes)");
+
+static_assert(((SET_HEATER_STATE_CMD_LEN % 2) == 0),
+              "set_heater_state_cmd_t struct not 16 bit aligned");
 
 // set heater state command
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_heater_state_all_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } set_heater_state_all_cmd_t;
 
 #define SET_HEATER_STATE_ALL_CMD_LEN sizeof(set_heater_state_all_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
-    (26 == SET_HEATER_STATE_ALL_CMD_LEN),
-    "set_heater_state_all_cmd_t struct size incorrect (expected 26 bytes)");
+    (28 == SET_HEATER_STATE_ALL_CMD_LEN),
+    "set_heater_state_all_cmd_t struct size incorrect (expected 28 bytes)");
+
+static_assert(((SET_HEATER_STATE_ALL_CMD_LEN % 4) == 0),
+              "set_heater_state_all_cmd_t struct not 32 bit aligned");
 
 // heater telemetry message
 typedef struct {
     main_bus_hdr_t msg_hdr;
     heater_telem_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } heater_telem_msg_t;
 
 #define HEATER_TELEM_MSG_LEN sizeof(heater_telem_msg_t)
 
-// Preprocessor check of struct size
-static_assert(
-    (56 == HEATER_TELEM_MSG_LEN),
-    "heater_telem_msg_t struct size incorrect (expected 56 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert((64 == HEATER_TELEM_MSG_LEN),
+              "heater_telem_msg_t struct size incorrect (expected 64 bytes)");
+
+static_assert(((HEATER_TELEM_MSG_LEN % 4) == 0),
+              "heater_telem_msg_t struct not 32 bit aligned");
 
 #endif /* _heater_control_msgs_h */

--- a/fsw/public_inc/master_comms_bus_protocol.h
+++ b/fsw/public_inc/master_comms_bus_protocol.h
@@ -4,8 +4,6 @@
  *
  * @brief       definitions for master comms bus protocol
  *
- * @date   		20 Feb 2022
- *
  * @authors 	Tenzin Crouch
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  *
@@ -71,14 +69,26 @@ typedef struct {
 
 #define MAIN_BUS_HDR_LEN sizeof(main_bus_hdr_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert((8 == MAIN_BUS_HDR_LEN),
               "main_bus_hdr_t struct size incorrect (expected 8 bytes)");
 
+static_assert(((MAIN_BUS_HDR_LEN % 2) == 0),
+              "main_bus_hdr_t struct not 16 bit aligned");
+              
 typedef struct {
     int16_t reboot_counter;        // the number of times MSP has rebooted
     int16_t invalid_msg_counter;   // the number of times an MSP has received
                                    // invalid msgs
 } msp_health_payload_t;
+
+#define MSP_HEALTH_PAYLOAD_LEN sizeof(msp_health_payload_t)
+
+// Preprocessor struct size and alignment checks
+static_assert((4 == MSP_HEALTH_PAYLOAD_LEN),
+              "msp_health_payload_t struct size incorrect (expected 4 bytes)");
+
+static_assert(((MSP_HEALTH_PAYLOAD_LEN % 2) == 0),
+              "msp_health_payload_t struct not 16 bit aligned");
 
 #endif /* _master_comms_bus_protocol_h */

--- a/fsw/public_inc/master_comms_msgs.h
+++ b/fsw/public_inc/master_comms_msgs.h
@@ -5,8 +5,6 @@
  * @brief     definitions for all messages related to power switching master
  *comms bus
  *
- * @date   		20 Feb 2022
- *
  * @authors 	Tenzin Crouch
  * @author 		Carnegie Mellon University, Planetary Robotics Lab
  *
@@ -29,9 +27,19 @@
  **************************************************************************/
 
 typedef struct {
-    int16_t valid_counter;        // the number of valid spi messages
+    int16_t valid_counter;         // the number of valid spi messages
     int16_t invalid_msg_counter;   // the number of invalid spi messages
 } spi_health_payload_t;
+
+#define SPI_HEALTH_PAYLOAD_LEN sizeof(spi_health_payload_t)
+
+// Preprocessor struct size and alignment checks
+static_assert(
+    (4 == SPI_HEALTH_PAYLOAD_LEN),
+    "spi_health_payload_t struct size incorrect (expected 4 bytes)");
+
+static_assert(((SPI_HEALTH_PAYLOAD_LEN % 2) == 0),
+              "spi_health_payload_t struct not 16 bit aligned");
 
 typedef struct {
     motor_health_payload_t motor_health_data;
@@ -45,10 +53,13 @@ typedef struct {
 
 #define SENSOR_TELEM_PAYLOAD_LEN sizeof(sensor_telem_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
-    (360 == SENSOR_TELEM_PAYLOAD_LEN),
-    "sensor_telem_payload_t struct size incorrect (expected 360 bytes)");
+    (368 == SENSOR_TELEM_PAYLOAD_LEN),
+    "sensor_telem_payload_t struct size incorrect (expected 368 bytes)");
+
+static_assert(((SENSOR_TELEM_PAYLOAD_LEN % 4) == 0),
+              "sensor_telem_payload_t struct not 32 bit aligned");
 
 /**************************************************************************
  * PERIPHERAL-MASTER COMMS LINK MESSAGE DEFINITIONS
@@ -77,10 +88,13 @@ typedef struct {
 
 #define PERIPHERAL_SENSOR_TELEM_MSG_LEN sizeof(peripheral_sensor_telem_msg_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
-    (364 == PERIPHERAL_SENSOR_TELEM_MSG_LEN),
-    "peripheral_sensor_telem_msg_t struct size incorrect (expected 364 bytes)");
+    (372 == PERIPHERAL_SENSOR_TELEM_MSG_LEN),
+    "peripheral_sensor_telem_msg_t struct size incorrect (expected 372 bytes)");
+
+static_assert(((PERIPHERAL_SENSOR_TELEM_MSG_LEN % 4) == 0),
+              "peripheral_sensor_telem_msg_t struct not 32 bit aligned");
 
 typedef struct {
     set_wheel_speed_all_cmd_t wheel_speed_cmd;
@@ -93,9 +107,11 @@ typedef struct {
 
 #define OBC_SPI_CMD_LEN sizeof(obc_spi_cmd_t)
 
-// Preprocessor check of struct size
-static_assert((364 == OBC_SPI_CMD_LEN),
-              "obc_spi_cmd_t struct size incorrect (expected 364 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert((PERIPHERAL_SENSOR_TELEM_MSG_LEN == OBC_SPI_CMD_LEN),
+              "obc_spi_cmd_t struct size does not match peripheral_sensor_telem_msg_t struct size)");
+
+static_assert(((OBC_SPI_CMD_LEN % 4) == 0),
+              "obc_spi_cmd_t struct not 32 bit aligned");
 
 #endif /* master_comms_msgs_h */
-

--- a/fsw/public_inc/motor_control_msgs.h
+++ b/fsw/public_inc/motor_control_msgs.h
@@ -54,10 +54,13 @@ typedef struct {
 
 #define WHEEL_MOTOR_HEALTH_LEN sizeof(wheel_motor_health_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (24 == WHEEL_MOTOR_HEALTH_LEN),
-    " wheel_motor_health_t struct size incorrect (expected 24 bytes)");
+    "wheel_motor_health_t struct size incorrect (expected 24 bytes)");
+
+static_assert(((WHEEL_MOTOR_HEALTH_LEN % 4) == 0),
+              "wheel_motor_health_t struct not 32 bit aligned");
 
 typedef struct {
     volatile int16_t motor_actual_velocity;    // The actual velocity
@@ -69,10 +72,14 @@ typedef struct {
 
 #define SOLAR_PANEL_MOTOR_HEALTH_LEN sizeof(solar_panel_motor_health_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (8 == SOLAR_PANEL_MOTOR_HEALTH_LEN),
     "solar_panel_motor_health_t struct size incorrect (expected 8 bytes)");
+
+static_assert(((SOLAR_PANEL_MOTOR_HEALTH_LEN % 4) == 0),
+              "solar_panel_motor_health_t struct not 32 bit aligned");
+
 
 /**************************************************************************
  * MOONRANGER MESSAGE PAYLOADS
@@ -87,20 +94,32 @@ typedef struct {
 
 #define SET_WHEEL_SPEED_ALL_PAYLOAD_LEN sizeof(set_wheel_speed_all_payload_t)
 
+// Preprocessor struct size and alignment checks
+static_assert(
+    (8 == SET_WHEEL_SPEED_ALL_PAYLOAD_LEN),
+    "set_wheel_speed_all_payload_t struct size incorrect (expected 8 bytes)");
+
+static_assert(((SET_WHEEL_SPEED_ALL_PAYLOAD_LEN % 4) == 0),
+              "set_wheel_speed_all_payload_t struct not 32 bit aligned");
+
+
 // set motor PID command
 typedef struct {
     pid_gains_t motor_pid_gains;
     motor_id_t motor_id;
-    uint8_t __padding[3];
+    uint8_t __padding[3];  // ensure 16 bit alignment
 } set_motor_pid_payload_t;
 
 #define SET_MOTOR_PID_PAYLOAD_LEN sizeof(set_motor_pid_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (16 == SET_MOTOR_PID_PAYLOAD_LEN),
     "set_motor_pid_payload_t struct size incorrect (expected 16 bytes)");
 
+static_assert(((SET_MOTOR_PID_PAYLOAD_LEN % 4) == 0),
+              "set_motor_pid_payload_t struct not 32 bit aligned");
+    
 // set solar panel state command
 typedef struct {
     solar_panel_state_t panel_state;
@@ -110,10 +129,13 @@ typedef struct {
 #define SET_SOLAR_PANEL_STATE_PAYLOAD_LEN \
     sizeof(set_solar_panel_state_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (2 == SET_SOLAR_PANEL_STATE_PAYLOAD_LEN),
     "set_solar_panel_state_payload_t struct size incorrect (expected 2 bytes)");
+
+static_assert(((SET_SOLAR_PANEL_STATE_PAYLOAD_LEN % 2) == 0),
+              "set_solar_panel_state_payload_t struct not 16 bit aligned");
 
 // motor health message
 typedef struct {
@@ -127,10 +149,14 @@ typedef struct {
 
 #define MOTOR_HEALTH_PAYLOAD_LEN sizeof(motor_health_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (108 == MOTOR_HEALTH_PAYLOAD_LEN),
     "motor_health_payload_t struct size incorrect (expected 108 bytes)");
+
+
+static_assert(((MOTOR_HEALTH_PAYLOAD_LEN % 4) == 0),
+              "motor_health_payload_t struct not 32 bit aligned");
 
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
@@ -138,53 +164,71 @@ static_assert(
 typedef struct {
     main_bus_hdr_t msg_hdr;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding; //for consistent footer on MSPs commands
 } get_motor_telem_cmd_t;
 
 #define GET_MOTOR_TELEM_CMD_LEN sizeof(get_motor_telem_cmd_t)
+
+// Preprocessor struct size and alignment checks
+static_assert(
+    (12 == GET_MOTOR_TELEM_CMD_LEN),
+    "motor_health_payload_t struct size incorrect (expected 12 bytes)");
+
+
+static_assert(((GET_MOTOR_TELEM_CMD_LEN % 4) == 0),
+              "set_motor_pid_payload_t struct not 32 bit aligned");
 
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_wheel_speed_all_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_wheel_speed_all_cmd_t;
 
 #define SET_WHEEL_SPEED_ALL_CMD_LEN sizeof(set_wheel_speed_all_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (20 == SET_WHEEL_SPEED_ALL_CMD_LEN),
     "set_wheel_speed_all_cmd_t struct size incorrect (expected 20 bytes)");
+
+
+static_assert(((SET_WHEEL_SPEED_ALL_CMD_LEN % 4) == 0),
+              "set_wheel_speed_all_cmd_t struct not 32 bit aligned");
 
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_motor_pid_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_motor_pid_cmd_t;
 
 #define SET_MOTOR_PID_CMD_LEN sizeof(set_motor_pid_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (28 == SET_MOTOR_PID_CMD_LEN),
     "set_motor_pid_cmd_t struct size incorrect (expected 28 bytes)");
+
+static_assert(((SET_MOTOR_PID_CMD_LEN % 4) == 0),
+              "set_motor_pid_cmd_t struct not 32 bit aligned");
 
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_solar_panel_state_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_solar_panel_state_cmd_t;
 
 #define SET_SOLAR_PANEL_STATE_CMD_LEN sizeof(set_solar_panel_state_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (14 == SET_SOLAR_PANEL_STATE_CMD_LEN),
     "set_solar_panel_state_cmd_t struct size incorrect (expected 14 bytes)");
 
+static_assert(((SET_SOLAR_PANEL_STATE_CMD_LEN % 2) == 0),
+              "set_solar_panel_state_cmd_t struct not 16 bit aligned");
 typedef struct {
     main_bus_hdr_t msg_hdr;
     motor_health_payload_t payload;
@@ -194,9 +238,13 @@ typedef struct {
 
 #define MOTOR_HEALTH_MSG_LEN sizeof(motor_health_msg_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (120 == MOTOR_HEALTH_MSG_LEN),
     "motor_health_msg_t struct size incorrect (expected 120 bytes)");
+
+
+static_assert(((MOTOR_HEALTH_MSG_LEN % 4) == 0),
+              "motor_health_msg_t struct not 32 bit aligned");
 
 #endif /* _motor_controller_msgs_h */

--- a/fsw/public_inc/nss_msgs.h
+++ b/fsw/public_inc/nss_msgs.h
@@ -54,6 +54,9 @@ typedef struct {
 static_assert((96 == NSS_TELEM_PAYLOAD_LEN),
               "nss_telem_payload_t struct size incorrect (expected 96 bytes)");
 
+static_assert(((NSS_TELEM_PAYLOAD_LEN % 4) == 0),
+              "nss_telem_payload_t struct not 32 bit aligned");
+
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
  **************************************************************************/
@@ -70,11 +73,14 @@ typedef struct {
 static_assert((12 == GET_NSS_TELEM_CMD_LEN),
               "get_nss_telem_cmd_t struct size incorrect (expected 12 bytes)");
 
+static_assert(((GET_NSS_TELEM_CMD_LEN % 4) == 0),
+              "get_nss_telem_cmd_t struct not 32 bit aligned");
+
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_nss_params_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_nss_params_cmd_t;
 
 #define SET_NSS_PARAMS_CMD_LEN sizeof(set_nss_params_cmd_t)
@@ -82,6 +88,9 @@ typedef struct {
 // Preprocessor check of struct size
 static_assert((14 == SET_NSS_PARAMS_CMD_LEN),
               "set_nss_params_cmd_t struct size incorrect (expected 14 bytes)");
+
+static_assert(((SET_NSS_PARAMS_CMD_LEN % 2) == 0),
+              "set_nss_params_cmd_t struct not 16 bit aligned");
 
 typedef struct {
     main_bus_hdr_t msg_hdr;
@@ -95,5 +104,8 @@ typedef struct {
 // Preprocessor check of struct size
 static_assert((108 == NSS_TELEM_MSG_LEN),
               "nss_telem_msg_t struct size incorrect (expected 108 bytes)");
+
+static_assert(((NSS_TELEM_MSG_LEN % 4) == 0),
+              "nss_telem_msg_t struct not 32 bit aligned");
 
 #endif /* _nss_msgs_h */

--- a/fsw/public_inc/power_switching_msgs.h
+++ b/fsw/public_inc/power_switching_msgs.h
@@ -62,9 +62,13 @@ typedef struct {
 
 #define SET_SWITCH_STATE_PAYLOAD_LEN sizeof(set_switch_state_payload_t)
 
-// Preprocessor check of struct size
-static_assert((2 == SET_SWITCH_STATE_PAYLOAD_LEN),
-              "set_switch_state_payload_t struct size incorrect (expected 2 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (2 == SET_SWITCH_STATE_PAYLOAD_LEN),
+    "set_switch_state_payload_t struct size incorrect (expected 2 bytes)");
+
+static_assert(((SET_SWITCH_STATE_PAYLOAD_LEN % 2) == 0),
+              "set_switch_state_payload_t struct not 16 bit aligned");
 
 // set power switching state all command payload
 typedef struct {
@@ -74,9 +78,13 @@ typedef struct {
 
 #define SET_SWITCH_STATE_ALL_PAYLOAD_LEN sizeof(set_switch_state_all_payload_t)
 
-// Preprocessor check of struct size
-static_assert((16 == SET_SWITCH_STATE_ALL_PAYLOAD_LEN),
-              "set_switch_state_all_payload_t struct size incorrect (expected 16 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (16 == SET_SWITCH_STATE_ALL_PAYLOAD_LEN),
+    "set_switch_state_all_payload_t struct size incorrect (expected 16 bytes)");
+
+static_assert(((SET_SWITCH_STATE_PAYLOAD_LEN % 2) == 0),
+              "set_switch_state_all_payload_t struct not 16 bit aligned");
 
 // reset power switch command payload
 typedef struct {
@@ -86,9 +94,13 @@ typedef struct {
 
 #define RESET_SWITCH_PAYLOAD_LEN sizeof(reset_switch_payload_t)
 
-// Preprocessor check of struct size
-static_assert((2 == RESET_SWITCH_PAYLOAD_LEN),
-              "reset_switch_payload_t struct size incorrect (expected 2 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (2 == RESET_SWITCH_PAYLOAD_LEN),
+    "reset_switch_payload_t struct size incorrect (expected 2 bytes)");
+
+static_assert(((SET_SWITCH_STATE_PAYLOAD_LEN % 2) == 0),
+              "set_switch_state_all_payload_t struct not 16 bit aligned");
 
 // power switching telemetry payload
 typedef struct {
@@ -100,9 +112,13 @@ typedef struct {
 
 #define POWER_SWITCH_TELEM_LEN sizeof(power_switch_telem_payload_t)
 
-// Preprocessor check of struct size
-static_assert((52 == POWER_SWITCH_TELEM_LEN),
-              "power_switch_telem_payload_t struct size incorrect (expected 52 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (52 == POWER_SWITCH_TELEM_LEN),
+    "power_switch_telem_payload_t struct size incorrect (expected 52 bytes)");
+
+static_assert(((POWER_SWITCH_TELEM_LEN % 4) == 0),
+              "power_switch_telem_payload_t struct not 32 bit aligned");
 
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
@@ -110,70 +126,89 @@ static_assert((52 == POWER_SWITCH_TELEM_LEN),
 // get power switching telemtry command
 typedef struct {
     main_bus_hdr_t msg_hdr;
-    uint16_t checksum;
-    uint16_t __padding;
+    uint16_t checksum; 
+    uint16_t __padding; //for consistent footer on MSPs commands
 } get_switch_telem_cmd_t;
 
 #define GET_SWITCH_TELEM_CMD_LEN sizeof(get_switch_telem_cmd_t)
 
-// Preprocessor check of struct size
-static_assert((12 == GET_SWITCH_TELEM_CMD_LEN),
-              "get_switch_telem_cmd_t struct size incorrect (expected 12 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (12 == GET_SWITCH_TELEM_CMD_LEN),
+    "get_switch_telem_cmd_t struct size incorrect (expected 12 bytes)");
+
+static_assert(((GET_SWITCH_TELEM_CMD_LEN % 4) == 0),
+              "get_switch_telem_cmd_t struct not 32 bit aligned");
 
 // set power switching state command
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_switch_state_payload_t payload;
-    uint16_t checksum;
-    uint16_t __padding;
+    uint16_t checksum; 
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_switch_state_cmd_t;
 
 #define SET_SWITCH_STATE_CMD_LEN sizeof(set_switch_state_cmd_t)
 
-// Preprocessor check of struct size
-static_assert((14 == SET_SWITCH_STATE_CMD_LEN),
-              "set_switch_state_cmd_t struct size incorrect (expected 14 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (14 == SET_SWITCH_STATE_CMD_LEN),
+    "set_switch_state_cmd_t struct size incorrect (expected 14 bytes)");
+
+static_assert(((SET_SWITCH_STATE_CMD_LEN % 2) == 0),
+              "set_switch_state_cmd_t struct not 16 bit aligned");
 
 // set power switching state command
 typedef struct {
     main_bus_hdr_t msg_hdr;
     set_switch_state_all_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;
+    uint16_t __padding; //for consistent footer on MSPs commands
 } set_switch_state_all_cmd_t;
 
 #define SET_SWITCH_STATE_ALL_CMD_LEN sizeof(set_switch_state_all_cmd_t)
 
-// Preprocessor check of struct size
-static_assert((28 == SET_SWITCH_STATE_ALL_CMD_LEN),
-              "set_switch_state_all_cmd_t struct size incorrect (expected 28 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (28 == SET_SWITCH_STATE_ALL_CMD_LEN),
+    "set_switch_state_all_cmd_t struct size incorrect (expected 28 bytes)");
+
+static_assert(((SET_SWITCH_STATE_ALL_CMD_LEN % 2) == 0),
+              "set_switch_state_all_cmd_t struct not 16 bit aligned");
 
 // reset power switch command
 typedef struct {
     main_bus_hdr_t msg_hdr;
     reset_switch_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;
+    uint16_t __padding; //for consistent footer on MSPs
 } reset_switch_cmd_t;
 
 #define RESET_SWITCH_CMD_LEN sizeof(reset_switch_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert((14 == RESET_SWITCH_CMD_LEN),
               "reset_switch_cmd_t struct size incorrect (expected 14 bytes)");
+
+static_assert(((RESET_SWITCH_CMD_LEN % 2) == 0),
+              "reset_switch_cmd_t struct not 16 bit aligned");
 
 // power switch telemetry message
 typedef struct {
     main_bus_hdr_t msg_hdr;
     power_switch_telem_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;
+    uint16_t __padding; //for consistent footer on MSPs commands
 } power_switch_telem_msg_t;
 
 #define POWER_SWITCH_TELEM_MSG_LEN sizeof(power_switch_telem_msg_t)
 
-// Preprocessor check of struct size
-static_assert((64 == POWER_SWITCH_TELEM_MSG_LEN),
-              "power_switch_telem_msg_t struct size incorrect (expected 64 bytes)");
+// Preprocessor struct size and alignment checks
+static_assert(
+    (64 == POWER_SWITCH_TELEM_MSG_LEN),
+    "power_switch_telem_msg_t struct size incorrect (expected 64 bytes)");
+
+static_assert(((POWER_SWITCH_TELEM_MSG_LEN % 4) == 0),
+              "power_switch_telem_msg_t struct not 32 bit aligned");
 
 #endif /* _power_switching_msgs_h */

--- a/fsw/public_inc/sunsensor_msgs.h
+++ b/fsw/public_inc/sunsensor_msgs.h
@@ -28,9 +28,12 @@ typedef struct {
 
 #define SUN_SENS_ANGLES_LEN sizeof(sun_sensor_angles_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert((12 == SUN_SENS_ANGLES_LEN),
               "sun_sensor_angles_t struct size incorrect (expected 12 bytes)");
+
+static_assert(((SUN_SENS_ANGLES_LEN % 2) == 0),
+              "sun_sensor_angles_t struct not 16 bit aligned");
 
 typedef struct {
     uint32_t uSSA1F;   // filtered voltage 1
@@ -39,12 +42,16 @@ typedef struct {
     uint32_t uSSA4F;   // filtered voltage 4
 } sun_sensor_filtered_volts_t;
 
+#define SUN_SENS_FILTERED_VOLTS_LEN sizeof(sun_sensor_filtered_volts_t)
+
 typedef struct {
     uint32_t uSSA1;   // unfiltered voltage 1
     uint32_t uSSA2;   // unfiltered voltage 2
     uint32_t uSSA3;   // unfiltered voltage 3
     uint32_t uSSA4;   // unfiltered voltage 4
 } sun_sensor_unfiltered_volts_t;
+
+#define SUN_SENS_UNFILTERED_VOLTS_LEN sizeof(sun_sensor_unfiltered_volts_t)
 
 /**************************************************************************
  * MOONRANGER MESSAGE PAYLOADS
@@ -60,10 +67,13 @@ typedef struct {
 
 #define SUNSENSOR_TELEM_PAYLOAD_LEN sizeof(sunsensor_telem_payload_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (52 == SUNSENSOR_TELEM_PAYLOAD_LEN),
     "sunsensor_telem_payload_t struct size incorrect (expected 52 bytes)");
+
+static_assert(((SUNSENSOR_TELEM_PAYLOAD_LEN % 4) == 0),
+              "sunsensor_telem_payload_t struct not 32 bit aligned");
 
 /**************************************************************************
  * MASTER COMMS BUS UART MESSAGE DEFINITIONS
@@ -72,30 +82,36 @@ static_assert(
 typedef struct {
     main_bus_hdr_t msg_hdr;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } get_sunsensor_data_cmd_t;
 
 #define GET_SUNSENSOR_DATA_CMD_LEN sizeof(get_sunsensor_data_cmd_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (12 == GET_SUNSENSOR_DATA_CMD_LEN),
     "get_sunsensor_data_cmd_t struct size incorrect (expected 12 bytes)");
+
+static_assert(((GET_SUNSENSOR_DATA_CMD_LEN % 4) == 0),
+              "get_sunsensor_data_cmd_t struct not 32 bit aligned");
 
 // sun sensor telem message
 typedef struct {
     main_bus_hdr_t msg_hdr;
     sunsensor_telem_payload_t payload;
     uint16_t checksum;
-    uint16_t __padding;   // ensure messages are 32 bit aligned for consistency
+    uint16_t __padding;   //for consistent footer on MSPs commands
 } sunsensor_telem_msg_t;
 
 #define SUNSENSOR_TELEM_LEN sizeof(sunsensor_telem_msg_t)
 
-// Preprocessor check of struct size
+// Preprocessor struct size and alignment checks
 static_assert(
     (64 == SUNSENSOR_TELEM_LEN),
     "sunsensor_telem_msg_t struct size incorrect (expected 64 bytes)");
 #define GET_SUNSENSOR_TELEM_LEN sizeof(sunsensor_telem_msg_t)
+
+static_assert(((SUNSENSOR_TELEM_LEN % 4) == 0),
+              "sunsensor_telem_msg_t struct not 32 bit aligned");
 
 #endif /* _sunsensor_msgs_h */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds additional struct alignment checks to ensure that all telemetry messages are at least 32 bit aligned and all command messages are at least 16 bit aligne.d

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves issues found with changes to rover messages propagating into other areas with unexpected padding.

Changes have been tested by building using cmake. Testing still to occur with main branch peripheral devices.