### PR TITLE
Add message for publishing rectified images

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -79,6 +79,7 @@
 #define STEREO_HK_TLM_MID 0x09C1
 #define STEREO_NEW_PCL_TLM_MID 0x09C2
 #define STEREO_NEW_DISP_TLM_MID 0x09C3
+#define STEREO_RECTIFIED_IMG_SAVED_TLM_MID 0x09C4
 
 /**
  * Planner Message IDs
@@ -282,8 +283,6 @@
 #define SCH_TLM_SPARE1                 0x0899
 #define SCH_TLM_SPARE2                 0x089A
 */
-
-#define STEREO_RECTIFIED_IMG_SAVED_TLM_MID 0x089B
 
 #endif /* _moonranger_msgids_h_ */
 

--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -283,6 +283,8 @@
 #define SCH_TLM_SPARE2                 0x089A
 */
 
+#define STEREO_RECTIFIED_IMG_SAVED_TLM_MID 0x089B
+
 #endif /* _moonranger_msgids_h_ */
 
 /************************/

--- a/fsw/public_inc/stereo_reconstructor_msgs.h
+++ b/fsw/public_inc/stereo_reconstructor_msgs.h
@@ -66,6 +66,11 @@ typedef struct {
     uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK STEREO_SendDispMsgTlm_t;
 
+typedef struct
+{
+  uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+} OS_PACK STEREO_SendRectifiedStereoImgTlm_t;
+
 /*
  * Buffer to hold telemetry data prior to sending
  * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type


### PR DESCRIPTION

## Description
Add a message that will be sent out to indicate that a new rectified image is published to the software bus. This message will be used for visual odometry.


## How has this been tested?
I have a branch that runs with this 
Also it's not much code so I'm pretty sure it's fine

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [x] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
