### PR TITLE
Add goal reached message and related structures

### DIFF
--- a/fsw/public_inc/moonranger_msgids.h
+++ b/fsw/public_inc/moonranger_msgids.h
@@ -90,6 +90,8 @@
 #define PLANNER_CMD_MID 0x1A00
 #define PLANNER_SEND_HK_MID 0x1A01
 #define PLANNER_HK_TLM_MID 0x0A01
+/* Telemetry that indicates the goal has been reached */
+#define PLANNER_GOAL_REACHED_MID 0x0A02
 
 /**
  * Mapper Message IDs

--- a/fsw/public_inc/planner_msgs.h
+++ b/fsw/public_inc/planner_msgs.h
@@ -88,6 +88,23 @@ typedef union
     PLANNER_HkTlm_t      HkTlm;
 } PLANNER_HkBuffer_t;
 
+/**
+ * Type definition (PLANNER goal reached message)
+ */
+
+typedef struct {
+    uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+} OS_PACK PLANNER_GoalReached_t;
+
+/**
+ * Buffer to hold telemetry data prior to sending
+ * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
+ */
+typedef union {
+    CFE_SB_Msg_t           MsgHdr;
+    PLANNER_GoalReached_t  GoalReachedTlm;
+} PLANNER_GoalReachedBuffer_t;
+
 #endif /* _planner_msgs_h */
 
 /************************/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a goal reached message so the planner can inform other apps when the rover enters the goal region.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Change is needed both for testing and if we want to use a rover executive in the future which may need to know if the planner thinks it has reached the goal.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Unit tests added to check that this is working how I expect.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [ ] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design documentation 
- [x] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [x] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
