### PR TITLE
change variable type to uint16_t for msp_healh_payload_t

### DIFF
--- a/fsw/public_inc/master_comms_bus_protocol.h
+++ b/fsw/public_inc/master_comms_bus_protocol.h
@@ -79,8 +79,8 @@ static_assert(((MAIN_BUS_HDR_LEN % 2) == 0),
 #endif
 
 typedef struct {
-    int16_t reboot_counter;        // the number of times MSP has rebooted
-    int16_t invalid_msg_counter;   // the number of times an MSP has received
+    uint16_t reboot_counter;        // the number of times MSP has rebooted
+    uint16_t invalid_msg_counter;   // the number of times an MSP has received
                                    // invalid msgs
 } msp_health_payload_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modify the variable type

## Description
<!--- Describe your changes in detail -->
change the variable types in struct msp_health_payload_t from int16_t to uint16_t

## 
<!--- Why is this change required? What problem does it solve? -->
fix the incorrect variable type
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [ ] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [ ] New and existing unit tests pass locally with my changes
- [ ] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [ ] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
