### PR TITLE
Scratch/autonomy/add seq id to cam if msgs

### DIFF
--- a/fsw/public_inc/camera_if_msgs.h
+++ b/fsw/public_inc/camera_if_msgs.h
@@ -67,8 +67,15 @@ typedef struct {
     uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
 } OS_PACK CAMERA_IF_ImgSavedTlm_t;
 
+/* SendStereoImg payload */
+typedef struct {
+    CFE_TIME_SysTime_t Timestamp;   // cFE mission time on when img is captured
+    uint32 SeqId = 0;               // counter, the n-th img captured
+} CAMERA_IF_SendStereoImgTlm_Payload_t;
+
 typedef struct {
     uint8 TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    CAMERA_IF_SendStereoImgTlm_Payload_t Payload;
 } OS_PACK CAMERA_IF_SendStereoImgTlm_t;
 
 /*

--- a/fsw/public_inc/camera_if_msgs.h
+++ b/fsw/public_inc/camera_if_msgs.h
@@ -70,7 +70,7 @@ typedef struct {
 /* SendStereoImg payload */
 typedef struct {
     CFE_TIME_SysTime_t Timestamp;   // cFE mission time on when img is captured
-    uint32 SeqId = 0;               // counter, the n-th img captured
+    uint32 SeqId;               // counter, the n-th img captured
 } CAMERA_IF_SendStereoImgTlm_Payload_t;
 
 typedef struct {
@@ -91,6 +91,11 @@ typedef union {
     CFE_SB_Msg_t MsgHdr;
     CAMERA_IF_ImgSavedTlm_t ImgSavedTlm;
 } CAMERA_IF_ImgSavedBuffer_t;
+
+typedef union {
+    CFE_SB_Msg_t MsgHdr;
+    CAMERA_IF_SendStereoImgTlm_t SendImgTlm;
+} CAMERA_IF_SendImgBuffer_t;
 
 #define CAMERA_IF_HK_TLM_LEN sizeof(CAMERA_IF_HkTlm_t)
 #define CAMERA_IF_HK_PAYLOAD_LEN sizeof(CAMERA_IF_HkTlm_Payload_t)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a payload to the telemetry message that camera_if sends when it publishes an image pair over sb_transport lib. This payload stores the timestamp and sequence ID associated with the image pair, so that the pose estimator can send an associated pose to the mapper.

## 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!-- Alternatively include a link to the test plan and report -->
Unit tests added testing this new payload. New and existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the `CONTRIBUTING.md` file
- [x] I have applied the .clang-format file to my changes
- [x] I have commented my code using Doxygen style comments (see Contributing MD for examples), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design documentation 
- [ ] I have updated any relevant parameters in the internal ICD
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this is a bug-fix, I have added tests that can catch similar bugs in the future
- [x] New and existing unit tests pass locally with my changes
- [x] For cfe apps I have reserved an empty address for my msgs_ids and perf_ids from the [tracking list](https://docs.google.com/spreadsheets/d/1yRUhNTRBOiGLswlsWftNaYlwGKDeNQ_fCnDYFrc_7fU/edit#gid=772812381) and checked that it does not clash with other apps
- [x] For new added message types, there is a timestamp included via either an explicit timestamp variable in the struct or buried in the a tlmHeader.
